### PR TITLE
fix: disable refresh interval input via native HTML attribute

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -12,6 +12,17 @@ Sourced from [GitHub Issues](https://github.com/MMoMM-org/obsidian-dynbedded/iss
 
 ---
 
+## Pending Confirmation
+
+### #13 — Refresh Interval Seconds can't be changed (Windows / Blue Topaz)
+`Setting.setDisabled()` only toggles the `is-disabled` CSS class on the wrapper; it does not set the native HTML `disabled` attribute on the input. The Blue Topaz theme on Windows applies `pointer-events: none` aggressively under that class, blocking interaction with the field. Fixed by also calling `TextComponent.setDisabled()` on the text component itself, which sets `inputEl.disabled` (browser-enforced, theme-independent).
+
+**Where:** `src/DynbeddedSettingTab.ts`
+
+**Complexity: XS**
+
+---
+
 ## Technical Debt
 
 ### TD-5 — Upgrade GitHub Actions to Node.js 24

--- a/src/DynbeddedSettingTab.ts
+++ b/src/DynbeddedSettingTab.ts
@@ -1,4 +1,4 @@
-import { App, PluginSettingTab, Setting } from 'obsidian';
+import { App, PluginSettingTab, Setting, TextComponent } from 'obsidian';
 import Dynbedded from './main';
 
 
@@ -69,6 +69,7 @@ export class DynbeddedSettingTab extends PluginSettingTab {
 			);
 
 		let intervalSetting: Setting;
+		let intervalText: TextComponent;
 
 		new Setting(containerEl)
 			.setName('Enable Auto-Refresh')
@@ -78,6 +79,7 @@ export class DynbeddedSettingTab extends PluginSettingTab {
 					this.plugin.log("Auto Refresh", value);
 					this.plugin.settings.autoRefresh = value;
 					await this.plugin.saveSettings();
+					intervalText.setDisabled(!value);
 					intervalSetting.setDisabled(!value);
 				})
 			);
@@ -86,7 +88,9 @@ export class DynbeddedSettingTab extends PluginSettingTab {
 			.setName('Refresh Interval (seconds)')
 			.setDesc('How often to re-render dynbedded blocks (10–3600 seconds).')
 			.addText(text => {
+				intervalText = text;
 				text.setValue(String(this.plugin.settings.refreshIntervalSeconds));
+				text.setDisabled(!this.plugin.settings.autoRefresh);
 				// Save and clamp only when the user leaves the field
 				text.inputEl.addEventListener('blur', async () => {
 					const parsed = parseInt(text.getValue(), 10);


### PR DESCRIPTION
## Summary
- Fixes #13: refresh interval field uneditable on Windows + Blue Topaz theme
- `Setting.setDisabled()` only toggles the `is-disabled` CSS class on the wrapper. Themes that apply `pointer-events: none` under that class (Blue Topaz on Windows) block interaction even after auto-refresh is toggled on.
- Now also calls `TextComponent.setDisabled()` so the native HTML `disabled` attribute is set on `inputEl` directly — browser-enforced, theme-independent.

## Test plan
- [ ] On Windows + Blue Topaz: open settings, enable Auto-Refresh, click into "Refresh Interval (seconds)" and change the value
- [ ] On macOS (default theme): regression check — toggling auto-refresh enables/disables the field as before
- [ ] Verify clamp-on-blur still works (10–3600 range)