### PR TITLE
fix: save refresh interval on every keystroke, not on blur

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -14,8 +14,12 @@ Sourced from [GitHub Issues](https://github.com/MMoMM-org/obsidian-dynbedded/iss
 
 ## Pending Confirmation
 
-### #13 — Refresh Interval Seconds can't be changed (Windows / Blue Topaz)
-`Setting.setDisabled()` only toggles the `is-disabled` CSS class on the wrapper; it does not set the native HTML `disabled` attribute on the input. The Blue Topaz theme on Windows applies `pointer-events: none` aggressively under that class, blocking interaction with the field. Fixed by also calling `TextComponent.setDisabled()` on the text component itself, which sets `inputEl.disabled` (browser-enforced, theme-independent).
+### #13 — Refresh Interval Seconds can't be changed (Windows)
+Two bugs combined into one symptom on Windows:
+
+1. **Disabled state (released in 1.2.2):** `Setting.setDisabled()` only toggles the `is-disabled` CSS class on the wrapper; it does not set the native HTML `disabled` attribute on the input. Fixed by also calling `TextComponent.setDisabled()` so `inputEl.disabled` is browser-enforced and theme-independent.
+
+2. **Save on blur unreliable on Windows:** When the settings modal closes, the input can be torn down before its `blur` event fires (Windows/Electron timing), so typed values were lost. Switched to saving on `input` (every keystroke) and using `blur` only to sync the displayed value with the clamped saved value. Avoids cursor-jump while typing because the displayed text is left alone during input — only the saved value is clamped.
 
 **Where:** `src/DynbeddedSettingTab.ts`
 

--- a/src/DynbeddedSettingTab.ts
+++ b/src/DynbeddedSettingTab.ts
@@ -91,14 +91,19 @@ export class DynbeddedSettingTab extends PluginSettingTab {
 				intervalText = text;
 				text.setValue(String(this.plugin.settings.refreshIntervalSeconds));
 				text.setDisabled(!this.plugin.settings.autoRefresh);
-				// Save and clamp only when the user leaves the field
-				text.inputEl.addEventListener('blur', async () => {
+				// Save on every keystroke — blur is unreliable on Windows when the
+				// settings modal closes (the input can be torn down before blur fires).
+				// We save the clamped value but leave the displayed text alone so the
+				// user can keep typing without the field jumping under their cursor.
+				text.inputEl.addEventListener('input', async () => {
 					const parsed = parseInt(text.getValue(), 10);
-					const clamped = isNaN(parsed) ? this.plugin.settings.refreshIntervalSeconds
-					                              : Math.max(10, Math.min(3600, parsed));
-					this.plugin.settings.refreshIntervalSeconds = clamped;
+					if (isNaN(parsed)) return;
+					this.plugin.settings.refreshIntervalSeconds = Math.max(10, Math.min(3600, parsed));
 					await this.plugin.saveSettings();
-					text.setValue(String(clamped));
+				});
+				// On blur, sync the displayed text with the (possibly clamped) saved value.
+				text.inputEl.addEventListener('blur', () => {
+					text.setValue(String(this.plugin.settings.refreshIntervalSeconds));
 				});
 			});
 		intervalSetting.setDisabled(!this.plugin.settings.autoRefresh);


### PR DESCRIPTION
## Summary
- Follow-up to #14 — disabled state was fixed in 1.2.2 but #13 reproduced on Windows because saving on `blur` is unreliable: the settings modal can tear down the input before its `blur` event dispatches, so typed values were lost.
- Switch the save trigger from `blur` to `input` (every keystroke). `blur` now only syncs the displayed text with the (clamped) saved value.
- Cursor-jump (the reason `blur`-only was originally introduced in `acb0b93`) is avoided by clamping only the **saved** value during typing — the displayed text stays as the user typed it until they leave the field.

## Test plan
- [ ] Windows: enable Auto-Refresh, change "Refresh Interval (seconds)" to e.g. `30`, close settings, reopen — value persists
- [ ] Windows: type `5000` — display stays `5000` while typing, on blur snaps to `3600` (max clamp)
- [ ] Windows: type `5` — display stays `5` while typing, on blur snaps to `10` (min clamp)
- [ ] macOS: regression check — same behaviour, no cursor jump while typing

reopens #13