### PR TITLE
fix: make disabled refresh interval visually obvious

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -14,10 +14,14 @@ Sourced from [GitHub Issues](https://github.com/MMoMM-org/obsidian-dynbedded/iss
 
 ## Pending Confirmation
 
-### #13 — Refresh Interval Seconds can't be changed (Windows / Blue Topaz)
-`Setting.setDisabled()` only toggles the `is-disabled` CSS class on the wrapper; it does not set the native HTML `disabled` attribute on the input. The Blue Topaz theme on Windows applies `pointer-events: none` aggressively under that class, blocking interaction with the field. Fixed by also calling `TextComponent.setDisabled()` on the text component itself, which sets `inputEl.disabled` (browser-enforced, theme-independent).
+### #13 — Refresh Interval Seconds can't be changed
+Two parts:
 
-**Where:** `src/DynbeddedSettingTab.ts`
+1. **Disabled state on Windows (released in 1.2.2):** `Setting.setDisabled()` only toggles the `is-disabled` CSS class on the wrapper; it does not set the native HTML `disabled` attribute on the input. Fixed by also calling `TextComponent.setDisabled()` so `inputEl.disabled` is browser-enforced.
+
+2. **Visual feedback when gated:** Field was technically disabled when Auto-Refresh was off, but the styling was too subtle on some platforms (Windows / Electron) — users couldn't tell the field was gated by the toggle and reported it as broken. Added an explicit description swap (*"Enable Auto-Refresh above to change this value"*) plus a CSS rule that lowers opacity and shows a `not-allowed` cursor on the disabled input.
+
+**Where:** `src/DynbeddedSettingTab.ts`, `styles.css`
 
 **Complexity: XS**
 

--- a/src/DynbeddedSettingTab.ts
+++ b/src/DynbeddedSettingTab.ts
@@ -71,6 +71,16 @@ export class DynbeddedSettingTab extends PluginSettingTab {
 		let intervalSetting: Setting;
 		let intervalText: TextComponent;
 
+		const intervalDescEnabled  = 'How often to re-render dynbedded blocks (10–3600 seconds).';
+		const intervalDescDisabled = 'Enable Auto-Refresh above to change this value (10–3600 seconds).';
+
+		const applyIntervalDisabled = (disabled: boolean) => {
+			intervalText.setDisabled(disabled);
+			intervalSetting.setDisabled(disabled);
+			intervalSetting.setDesc(disabled ? intervalDescDisabled : intervalDescEnabled);
+			intervalText.inputEl.toggleClass('dynbedded-disabled-input', disabled);
+		};
+
 		new Setting(containerEl)
 			.setName('Enable Auto-Refresh')
 			.setDesc('Automatically re-render dynbedded blocks at a set interval. Changes take effect when the note is reopened.')
@@ -79,18 +89,15 @@ export class DynbeddedSettingTab extends PluginSettingTab {
 					this.plugin.log("Auto Refresh", value);
 					this.plugin.settings.autoRefresh = value;
 					await this.plugin.saveSettings();
-					intervalText.setDisabled(!value);
-					intervalSetting.setDisabled(!value);
+					applyIntervalDisabled(!value);
 				})
 			);
 
 		intervalSetting = new Setting(containerEl)
 			.setName('Refresh Interval (seconds)')
-			.setDesc('How often to re-render dynbedded blocks (10–3600 seconds).')
 			.addText(text => {
 				intervalText = text;
 				text.setValue(String(this.plugin.settings.refreshIntervalSeconds));
-				text.setDisabled(!this.plugin.settings.autoRefresh);
 				// Save and clamp only when the user leaves the field
 				text.inputEl.addEventListener('blur', async () => {
 					const parsed = parseInt(text.getValue(), 10);
@@ -101,7 +108,7 @@ export class DynbeddedSettingTab extends PluginSettingTab {
 					text.setValue(String(clamped));
 				});
 			});
-		intervalSetting.setDisabled(!this.plugin.settings.autoRefresh);
+		applyIntervalDisabled(!this.plugin.settings.autoRefresh);
 
 // Leave this alone!
 		containerEl.createEl('hr');

--- a/styles.css
+++ b/styles.css
@@ -8,3 +8,11 @@
     margin-bottom: 20px;
 
 }
+/* Make disabled inputs in plugin settings unmistakably non-editable.
+   Some platforms (Windows / Electron) render the native :disabled style
+   too subtly, so users could not tell the field was gated. */
+.dynbedded-disabled-input {
+    opacity: 0.45;
+    cursor: not-allowed;
+    background: var(--background-modifier-form-field) !important;
+}


### PR DESCRIPTION
## Summary
Follow-up to #14 — closes #13 properly.

The 1.2.2 fix correctly set the native HTML \`disabled\` attribute on the interval input, but the visual styling remained too subtle on Windows / Electron. Users couldn't tell the field was gated by the Auto-Refresh toggle and read the *intentional* disabled state as a broken field.

Two changes:
- **Dynamic description.** While disabled the description now reads *"Enable Auto-Refresh above to change this value (10–3600 seconds)."* — explicit, theme-independent, can't be missed.
- **Stronger CSS.** Added a \`dynbedded-disabled-input\` class that drops the input to 45% opacity and switches the cursor to \`not-allowed\`, well beyond the platform default.

Both states are flipped through a single \`applyIntervalDisabled(disabled)\` helper so the description, class, and disabled state stay in sync on initial render and on every toggle change.

## Test plan
- [ ] Auto-Refresh OFF: field is clearly grayed out, cursor shows not-allowed, description reads "Enable Auto-Refresh above…"
- [ ] Auto-Refresh ON: field renders normally, description reads "How often to re-render…"
- [ ] Toggle on/off without closing settings — description and styling flip immediately
- [ ] Windows: same behaviour, disabled state is visually unambiguous

closes #13