### PR TITLE
chore(security): clear dependabot and code-scanning alerts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,17 @@ on:
   push:
     branches:
       - main
+permissions:
+  contents: read
+
 jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write       # create release commits, tags, GitHub Releases
+      issues: write         # comment on closed issues from semantic-release
+      pull-requests: write  # comment on PRs from semantic-release
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/TASKS.md
+++ b/TASKS.md
@@ -21,16 +21,17 @@ Sourced from [GitHub Issues](https://github.com/MMoMM-org/obsidian-dynbedded/iss
 
 **Complexity: XS**
 
+### Security & permissions cleanup
+- Resolved 20 open Dependabot alerts (handlebars / undici / lodash / picomatch / flatted) by running `npm audit fix`. All were transitive devDependencies of the build/release tooling — `npm audit --omit=dev` was already 0. No runtime impact on the published plugin (`dependencies: {}`); only the lock file changed.
+- Closed the open Code Scanning alert by adding an explicit `permissions:` block to `.github/workflows/release.yml`: workflow-default `contents: read`, with the release job elevated to `contents: write`, `issues: write`, and `pull-requests: write` for semantic-release.
+
+**Where:** `package-lock.json`, `.github/workflows/release.yml`
+
+**Complexity: XS**
+
 ---
 
 ## Technical Debt
-
-### TD-5 — Upgrade GitHub Actions to Node.js 24
-`actions/checkout@v2` and `actions/setup-node@v2` run on Node.js 20, which GitHub will force-migrate to Node.js 24 by default from **June 2, 2026**. Upgrade both to v4.
-
-**Where:** `.github/workflows/release.yml`
-
-**Complexity: XS**
 
 ### TD-6 — Auto-close issues and apply labels on release
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-dynbedded",
-	"version": "1.0.0",
+	"version": "1.2.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-dynbedded",
-			"version": "1.0.0",
+			"version": "1.2.2",
 			"license": "GPLv3",
 			"devDependencies": {
 				"@semantic-release/changelog": "^6.0.3",
@@ -60,9 +60,9 @@
 			}
 		},
 		"node_modules/@actions/http-client/node_modules/undici": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-			"integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+			"version": "6.25.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+			"integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -640,9 +640,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -697,9 +697,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2246,9 +2246,9 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-			"integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3193,9 +3193,9 @@
 			"license": "MIT"
 		},
 		"node_modules/eslint/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3484,9 +3484,9 @@
 			}
 		},
 		"node_modules/flatted": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
-			"integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -3661,9 +3661,9 @@
 			"license": "MIT"
 		},
 		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3734,9 +3734,9 @@
 			"license": "MIT"
 		},
 		"node_modules/handlebars": {
-			"version": "4.7.8",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-			"integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+			"version": "4.7.9",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+			"integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4268,16 +4268,16 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.23",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/lodash-es": {
-			"version": "4.17.23",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-			"integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+			"integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -4606,9 +4606,9 @@
 			}
 		},
 		"node_modules/npm": {
-			"version": "11.11.0",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-11.11.0.tgz",
-			"integrity": "sha512-82gRxKrh/eY5UnNorkTFcdBQAGpgjWehkfGVqAGlJjejEtJZGGJUqjo3mbBTNbc5BTnPKGVtGPBZGhElujX5cw==",
+			"version": "11.13.0",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-11.13.0.tgz",
+			"integrity": "sha512-cRmhaghDWA1lFgl3Ug4/VxDJdPBK/U+tNtnrl9kXunFqhWw1x4xL5txkNn7qzPuVfvXOmXyjHpMwsuk2uisbkg==",
 			"bundleDependencies": [
 				"@isaacs/string-locale-compare",
 				"@npmcli/arborist",
@@ -4687,19 +4687,19 @@
 			],
 			"dependencies": {
 				"@isaacs/string-locale-compare": "^1.1.0",
-				"@npmcli/arborist": "^9.4.0",
-				"@npmcli/config": "^10.7.1",
+				"@npmcli/arborist": "^9.4.3",
+				"@npmcli/config": "^10.8.1",
 				"@npmcli/fs": "^5.0.0",
 				"@npmcli/map-workspaces": "^5.0.3",
 				"@npmcli/metavuln-calculator": "^9.0.3",
 				"@npmcli/package-json": "^7.0.5",
 				"@npmcli/promise-spawn": "^9.0.1",
 				"@npmcli/redact": "^4.0.0",
-				"@npmcli/run-script": "^10.0.3",
-				"@sigstore/tuf": "^4.0.1",
+				"@npmcli/run-script": "^10.0.4",
+				"@sigstore/tuf": "^4.0.2",
 				"abbrev": "^4.0.0",
 				"archy": "~1.0.0",
-				"cacache": "^20.0.3",
+				"cacache": "^20.0.4",
 				"chalk": "^5.6.2",
 				"ci-info": "^4.4.0",
 				"fastest-levenshtein": "^1.0.16",
@@ -4709,24 +4709,24 @@
 				"hosted-git-info": "^9.0.2",
 				"ini": "^6.0.0",
 				"init-package-json": "^8.2.5",
-				"is-cidr": "^6.0.3",
+				"is-cidr": "^6.0.4",
 				"json-parse-even-better-errors": "^5.0.0",
 				"libnpmaccess": "^10.0.3",
-				"libnpmdiff": "^8.1.3",
-				"libnpmexec": "^10.2.3",
-				"libnpmfund": "^7.0.17",
+				"libnpmdiff": "^8.1.6",
+				"libnpmexec": "^10.2.6",
+				"libnpmfund": "^7.0.20",
 				"libnpmorg": "^8.0.1",
-				"libnpmpack": "^9.1.3",
+				"libnpmpack": "^9.1.6",
 				"libnpmpublish": "^11.1.3",
 				"libnpmsearch": "^9.0.1",
 				"libnpmteam": "^8.0.2",
 				"libnpmversion": "^8.0.3",
-				"make-fetch-happen": "^15.0.4",
-				"minimatch": "^10.2.2",
+				"make-fetch-happen": "^15.0.5",
+				"minimatch": "^10.2.5",
 				"minipass": "^7.1.3",
 				"minipass-pipeline": "^1.2.4",
 				"ms": "^2.1.2",
-				"node-gyp": "^12.2.0",
+				"node-gyp": "^12.3.0",
 				"nopt": "^9.0.0",
 				"npm-audit-report": "^7.0.0",
 				"npm-install-checks": "^8.0.0",
@@ -4736,7 +4736,7 @@
 				"npm-registry-fetch": "^19.1.1",
 				"npm-user-validate": "^4.0.0",
 				"p-map": "^7.0.4",
-				"pacote": "^21.4.0",
+				"pacote": "^21.5.0",
 				"parse-conflict-json": "^5.0.1",
 				"proc-log": "^6.1.0",
 				"qrcode-terminal": "^0.12.0",
@@ -4745,7 +4745,7 @@
 				"spdx-expression-parse": "^4.0.0",
 				"ssri": "^13.0.1",
 				"supports-color": "^10.2.2",
-				"tar": "^7.5.9",
+				"tar": "^7.5.13",
 				"text-table": "~0.2.0",
 				"tiny-relative-date": "^2.0.2",
 				"treeverse": "^3.0.0",
@@ -4773,24 +4773,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/@gar/promise-retry": {
-			"version": "1.0.2",
+			"version": "1.0.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"dependencies": {
-				"retry": "^0.13.1"
-			},
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/npm/node_modules/@gar/promise-retry/node_modules/retry": {
-			"version": "0.13.1",
-			"dev": true,
-			"inBundle": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
 			}
 		},
 		"node_modules/npm/node_modules/@isaacs/fs-minipass": {
@@ -4828,11 +4816,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/arborist": {
-			"version": "9.4.0",
+			"version": "9.4.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
+				"@gar/promise-retry": "^1.0.0",
 				"@isaacs/string-locale-compare": "^1.1.0",
 				"@npmcli/fs": "^5.0.0",
 				"@npmcli/installed-package-contents": "^4.0.0",
@@ -4875,7 +4864,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/config": {
-			"version": "10.7.1",
+			"version": "10.8.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -5041,7 +5030,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/run-script": {
-			"version": "10.0.3",
+			"version": "10.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -5050,8 +5039,7 @@
 				"@npmcli/package-json": "^7.0.0",
 				"@npmcli/promise-spawn": "^9.0.0",
 				"node-gyp": "^12.1.0",
-				"proc-log": "^6.0.0",
-				"which": "^6.0.0"
+				"proc-log": "^6.0.0"
 			},
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
@@ -5070,7 +5058,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@sigstore/core": {
-			"version": "3.1.0",
+			"version": "3.2.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0",
@@ -5079,7 +5067,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-			"version": "0.5.0",
+			"version": "0.5.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0",
@@ -5088,24 +5076,24 @@
 			}
 		},
 		"node_modules/npm/node_modules/@sigstore/sign": {
-			"version": "4.1.0",
+			"version": "4.1.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0",
 			"dependencies": {
+				"@gar/promise-retry": "^1.0.2",
 				"@sigstore/bundle": "^4.0.0",
-				"@sigstore/core": "^3.1.0",
+				"@sigstore/core": "^3.2.0",
 				"@sigstore/protobuf-specs": "^0.5.0",
-				"make-fetch-happen": "^15.0.3",
-				"proc-log": "^6.1.0",
-				"promise-retry": "^2.0.1"
+				"make-fetch-happen": "^15.0.4",
+				"proc-log": "^6.1.0"
 			},
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/@sigstore/tuf": {
-			"version": "4.0.1",
+			"version": "4.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0",
@@ -5221,7 +5209,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/brace-expansion": {
-			"version": "5.0.3",
+			"version": "5.0.5",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -5233,7 +5221,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/cacache": {
-			"version": "20.0.3",
+			"version": "20.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -5247,8 +5235,7 @@
 				"minipass-flush": "^1.0.5",
 				"minipass-pipeline": "^1.2.4",
 				"p-map": "^7.0.2",
-				"ssri": "^13.0.0",
-				"unique-filename": "^5.0.0"
+				"ssri": "^13.0.0"
 			},
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
@@ -5291,7 +5278,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/cidr-regex": {
-			"version": "5.0.3",
+			"version": "5.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause",
@@ -5347,7 +5334,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/diff": {
-			"version": "8.0.3",
+			"version": "8.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-3-Clause",
@@ -5367,7 +5354,6 @@
 		"node_modules/npm/node_modules/err-code": {
 			"version": "2.0.3",
 			"dev": true,
-			"inBundle": true,
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/exponential-backoff": {
@@ -5496,7 +5482,6 @@
 		"node_modules/npm/node_modules/imurmurhash": {
 			"version": "0.1.4",
 			"dev": true,
-			"inBundle": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.19"
@@ -5538,12 +5523,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/is-cidr": {
-			"version": "6.0.3",
+			"version": "6.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"cidr-regex": "^5.0.1"
+				"cidr-regex": "^5.0.4"
 			},
 			"engines": {
 				"node": ">=20"
@@ -5611,12 +5596,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmdiff": {
-			"version": "8.1.3",
+			"version": "8.1.6",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^9.4.0",
+				"@npmcli/arborist": "^9.4.3",
 				"@npmcli/installed-package-contents": "^4.0.0",
 				"binary-extensions": "^3.0.0",
 				"diff": "^8.0.2",
@@ -5630,13 +5615,13 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmexec": {
-			"version": "10.2.3",
+			"version": "10.2.6",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"@gar/promise-retry": "^1.0.0",
-				"@npmcli/arborist": "^9.4.0",
+				"@npmcli/arborist": "^9.4.3",
 				"@npmcli/package-json": "^7.0.0",
 				"@npmcli/run-script": "^10.0.0",
 				"ci-info": "^4.0.0",
@@ -5653,12 +5638,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmfund": {
-			"version": "7.0.17",
+			"version": "7.0.20",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^9.4.0"
+				"@npmcli/arborist": "^9.4.3"
 			},
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
@@ -5678,12 +5663,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmpack": {
-			"version": "9.1.3",
+			"version": "9.1.6",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^9.4.0",
+				"@npmcli/arborist": "^9.4.3",
 				"@npmcli/run-script": "^10.0.0",
 				"npm-package-arg": "^13.0.0",
 				"pacote": "^21.0.2"
@@ -5753,7 +5738,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/lru-cache": {
-			"version": "11.2.6",
+			"version": "11.3.5",
 			"dev": true,
 			"inBundle": true,
 			"license": "BlueOak-1.0.0",
@@ -5762,13 +5747,14 @@
 			}
 		},
 		"node_modules/npm/node_modules/make-fetch-happen": {
-			"version": "15.0.4",
+			"version": "15.0.5",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"@gar/promise-retry": "^1.0.0",
 				"@npmcli/agent": "^4.0.0",
+				"@npmcli/redact": "^4.0.0",
 				"cacache": "^20.0.1",
 				"http-cache-semantics": "^4.1.1",
 				"minipass": "^7.0.2",
@@ -5784,12 +5770,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/minimatch": {
-			"version": "10.2.2",
+			"version": "10.2.5",
 			"dev": true,
 			"inBundle": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"brace-expansion": "^5.0.2"
+				"brace-expansion": "^5.0.5"
 			},
 			"engines": {
 				"node": "18 || 20 || >=22"
@@ -5837,34 +5823,16 @@
 			}
 		},
 		"node_modules/npm/node_modules/minipass-flush": {
-			"version": "1.0.5",
+			"version": "1.0.6",
 			"dev": true,
 			"inBundle": true,
-			"license": "ISC",
+			"license": "BlueOak-1.0.0",
 			"dependencies": {
-				"minipass": "^3.0.0"
+				"minipass": "^7.1.3"
 			},
 			"engines": {
-				"node": ">= 8"
+				"node": ">=16 || 14 >=14.17"
 			}
-		},
-		"node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-			"version": "3.3.6",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC",
-			"dependencies": {
-				"yallist": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/npm/node_modules/minipass-flush/node_modules/yallist": {
-			"version": "4.0.0",
-			"dev": true,
-			"inBundle": true,
-			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/minipass-pipeline": {
 			"version": "1.2.4",
@@ -5945,7 +5913,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/node-gyp": {
-			"version": "12.2.0",
+			"version": "12.3.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -5953,12 +5921,12 @@
 				"env-paths": "^2.2.0",
 				"exponential-backoff": "^3.1.1",
 				"graceful-fs": "^4.2.6",
-				"make-fetch-happen": "^15.0.0",
 				"nopt": "^9.0.0",
 				"proc-log": "^6.0.0",
 				"semver": "^7.3.5",
 				"tar": "^7.5.4",
 				"tinyglobby": "^0.2.12",
+				"undici": "^6.25.0",
 				"which": "^6.0.0"
 			},
 			"bin": {
@@ -6122,7 +6090,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/pacote": {
-			"version": "21.4.0",
+			"version": "21.5.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -6234,7 +6202,6 @@
 		"node_modules/npm/node_modules/promise-retry": {
 			"version": "2.0.1",
 			"dev": true,
-			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
 				"err-code": "^2.0.2",
@@ -6288,7 +6255,6 @@
 		"node_modules/npm/node_modules/retry": {
 			"version": "0.12.0",
 			"dev": true,
-			"inBundle": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 4"
@@ -6427,7 +6393,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/tar": {
-			"version": "7.5.9",
+			"version": "7.5.13",
 			"dev": true,
 			"inBundle": true,
 			"license": "BlueOak-1.0.0",
@@ -6455,13 +6421,13 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/tinyglobby": {
-			"version": "0.2.15",
+			"version": "0.2.16",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
 				"fdir": "^6.5.0",
-				"picomatch": "^4.0.3"
+				"picomatch": "^4.0.4"
 			},
 			"engines": {
 				"node": ">=12.0.0"
@@ -6488,7 +6454,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
-			"version": "4.0.3",
+			"version": "4.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -6522,10 +6488,18 @@
 				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
+		"node_modules/npm/node_modules/undici": {
+			"version": "6.25.0",
+			"dev": true,
+			"inBundle": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18.17"
+			}
+		},
 		"node_modules/npm/node_modules/unique-filename": {
 			"version": "5.0.0",
 			"dev": true,
-			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"unique-slug": "^6.0.0"
@@ -6537,7 +6511,6 @@
 		"node_modules/npm/node_modules/unique-slug": {
 			"version": "6.0.0",
 			"dev": true,
-			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"imurmurhash": "^0.1.4"
@@ -6586,12 +6559,11 @@
 			}
 		},
 		"node_modules/npm/node_modules/write-file-atomic": {
-			"version": "7.0.0",
+			"version": "7.0.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"imurmurhash": "^0.1.4",
 				"signal-exit": "^4.0.1"
 			},
 			"engines": {
@@ -6933,10 +6905,11 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
 			},
@@ -8192,9 +8165,9 @@
 			}
 		},
 		"node_modules/tinyglobby/node_modules/picomatch": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -8311,9 +8284,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "7.22.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-			"integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+			"integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -8691,9 +8664,9 @@
 			},
 			"dependencies": {
 				"undici": {
-					"version": "6.23.0",
-					"resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-					"integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+					"version": "6.25.0",
+					"resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+					"integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
 					"dev": true
 				}
 			}
@@ -8972,9 +8945,9 @@
 					"dev": true
 				},
 				"brace-expansion": {
-					"version": "1.1.12",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-					"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+					"version": "1.1.14",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+					"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 					"dev": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
@@ -9016,9 +8989,9 @@
 					"dev": true
 				},
 				"brace-expansion": {
-					"version": "1.1.12",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-					"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+					"version": "1.1.14",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+					"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 					"dev": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
@@ -10003,9 +9976,9 @@
 			"dev": true
 		},
 		"brace-expansion": {
-			"version": "5.0.4",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-			"integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+			"version": "5.0.5",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
 			"dev": true,
 			"requires": {
 				"balanced-match": "^4.0.2"
@@ -10620,9 +10593,9 @@
 					"dev": true
 				},
 				"brace-expansion": {
-					"version": "1.1.12",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-					"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+					"version": "1.1.14",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+					"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 					"dev": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
@@ -10834,9 +10807,9 @@
 			}
 		},
 		"flatted": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.4.tgz",
-			"integrity": "sha512-3+mMldrTAPdta5kjX2G2J7iX4zxtnwpdA8Tr2ZSjkyPSanvbZAcy6flmtnXbEybHrDcU9641lxrMfFuUxVz9vA==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+			"integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
 			"dev": true
 		},
 		"from2": {
@@ -10953,9 +10926,9 @@
 					"dev": true
 				},
 				"brace-expansion": {
-					"version": "1.1.12",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-					"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+					"version": "1.1.14",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+					"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 					"dev": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
@@ -11018,9 +10991,9 @@
 			"dev": true
 		},
 		"handlebars": {
-			"version": "4.7.8",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
-			"integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+			"version": "4.7.9",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.9.tgz",
+			"integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
 			"dev": true,
 			"requires": {
 				"minimist": "^1.2.5",
@@ -11388,15 +11361,15 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.23",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
 			"dev": true
 		},
 		"lodash-es": {
-			"version": "4.17.23",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-			"integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+			"version": "4.18.1",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+			"integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
 			"dev": true
 		},
 		"lodash.capitalize": {
@@ -11621,25 +11594,25 @@
 			"dev": true
 		},
 		"npm": {
-			"version": "11.11.0",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-11.11.0.tgz",
-			"integrity": "sha512-82gRxKrh/eY5UnNorkTFcdBQAGpgjWehkfGVqAGlJjejEtJZGGJUqjo3mbBTNbc5BTnPKGVtGPBZGhElujX5cw==",
+			"version": "11.13.0",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-11.13.0.tgz",
+			"integrity": "sha512-cRmhaghDWA1lFgl3Ug4/VxDJdPBK/U+tNtnrl9kXunFqhWw1x4xL5txkNn7qzPuVfvXOmXyjHpMwsuk2uisbkg==",
 			"dev": true,
 			"requires": {
 				"@isaacs/string-locale-compare": "^1.1.0",
-				"@npmcli/arborist": "^9.4.0",
-				"@npmcli/config": "^10.7.1",
+				"@npmcli/arborist": "^9.4.3",
+				"@npmcli/config": "^10.8.1",
 				"@npmcli/fs": "^5.0.0",
 				"@npmcli/map-workspaces": "^5.0.3",
 				"@npmcli/metavuln-calculator": "^9.0.3",
 				"@npmcli/package-json": "^7.0.5",
 				"@npmcli/promise-spawn": "^9.0.1",
 				"@npmcli/redact": "^4.0.0",
-				"@npmcli/run-script": "^10.0.3",
-				"@sigstore/tuf": "^4.0.1",
+				"@npmcli/run-script": "^10.0.4",
+				"@sigstore/tuf": "^4.0.2",
 				"abbrev": "^4.0.0",
 				"archy": "~1.0.0",
-				"cacache": "^20.0.3",
+				"cacache": "^20.0.4",
 				"chalk": "^5.6.2",
 				"ci-info": "^4.4.0",
 				"fastest-levenshtein": "^1.0.16",
@@ -11649,24 +11622,24 @@
 				"hosted-git-info": "^9.0.2",
 				"ini": "^6.0.0",
 				"init-package-json": "^8.2.5",
-				"is-cidr": "^6.0.3",
+				"is-cidr": "^6.0.4",
 				"json-parse-even-better-errors": "^5.0.0",
 				"libnpmaccess": "^10.0.3",
-				"libnpmdiff": "^8.1.3",
-				"libnpmexec": "^10.2.3",
-				"libnpmfund": "^7.0.17",
+				"libnpmdiff": "^8.1.6",
+				"libnpmexec": "^10.2.6",
+				"libnpmfund": "^7.0.20",
 				"libnpmorg": "^8.0.1",
-				"libnpmpack": "^9.1.3",
+				"libnpmpack": "^9.1.6",
 				"libnpmpublish": "^11.1.3",
 				"libnpmsearch": "^9.0.1",
 				"libnpmteam": "^8.0.2",
 				"libnpmversion": "^8.0.3",
-				"make-fetch-happen": "^15.0.4",
-				"minimatch": "^10.2.2",
+				"make-fetch-happen": "^15.0.5",
+				"minimatch": "^10.2.5",
 				"minipass": "^7.1.3",
 				"minipass-pipeline": "^1.2.4",
 				"ms": "^2.1.2",
-				"node-gyp": "^12.2.0",
+				"node-gyp": "^12.3.0",
 				"nopt": "^9.0.0",
 				"npm-audit-report": "^7.0.0",
 				"npm-install-checks": "^8.0.0",
@@ -11676,7 +11649,7 @@
 				"npm-registry-fetch": "^19.1.1",
 				"npm-user-validate": "^4.0.0",
 				"p-map": "^7.0.4",
-				"pacote": "^21.4.0",
+				"pacote": "^21.5.0",
 				"parse-conflict-json": "^5.0.1",
 				"proc-log": "^6.1.0",
 				"qrcode-terminal": "^0.12.0",
@@ -11685,7 +11658,7 @@
 				"spdx-expression-parse": "^4.0.0",
 				"ssri": "^13.0.1",
 				"supports-color": "^10.2.2",
-				"tar": "^7.5.9",
+				"tar": "^7.5.13",
 				"text-table": "~0.2.0",
 				"tiny-relative-date": "^2.0.2",
 				"treeverse": "^3.0.0",
@@ -11694,19 +11667,9 @@
 			},
 			"dependencies": {
 				"@gar/promise-retry": {
-					"version": "1.0.2",
+					"version": "1.0.3",
 					"bundled": true,
-					"dev": true,
-					"requires": {
-						"retry": "^0.13.1"
-					},
-					"dependencies": {
-						"retry": {
-							"version": "0.13.1",
-							"bundled": true,
-							"dev": true
-						}
-					}
+					"dev": true
 				},
 				"@isaacs/fs-minipass": {
 					"version": "4.0.1",
@@ -11734,10 +11697,11 @@
 					}
 				},
 				"@npmcli/arborist": {
-					"version": "9.4.0",
+					"version": "9.4.3",
 					"bundled": true,
 					"dev": true,
 					"requires": {
+						"@gar/promise-retry": "^1.0.0",
 						"@isaacs/string-locale-compare": "^1.1.0",
 						"@npmcli/fs": "^5.0.0",
 						"@npmcli/installed-package-contents": "^4.0.0",
@@ -11774,7 +11738,7 @@
 					}
 				},
 				"@npmcli/config": {
-					"version": "10.7.1",
+					"version": "10.8.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -11889,7 +11853,7 @@
 					"dev": true
 				},
 				"@npmcli/run-script": {
-					"version": "10.0.3",
+					"version": "10.0.4",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -11897,8 +11861,7 @@
 						"@npmcli/package-json": "^7.0.0",
 						"@npmcli/promise-spawn": "^9.0.0",
 						"node-gyp": "^12.1.0",
-						"proc-log": "^6.0.0",
-						"which": "^6.0.0"
+						"proc-log": "^6.0.0"
 					}
 				},
 				"@sigstore/bundle": {
@@ -11910,30 +11873,30 @@
 					}
 				},
 				"@sigstore/core": {
-					"version": "3.1.0",
+					"version": "3.2.0",
 					"bundled": true,
 					"dev": true
 				},
 				"@sigstore/protobuf-specs": {
-					"version": "0.5.0",
+					"version": "0.5.1",
 					"bundled": true,
 					"dev": true
 				},
 				"@sigstore/sign": {
-					"version": "4.1.0",
+					"version": "4.1.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
+						"@gar/promise-retry": "^1.0.2",
 						"@sigstore/bundle": "^4.0.0",
-						"@sigstore/core": "^3.1.0",
+						"@sigstore/core": "^3.2.0",
 						"@sigstore/protobuf-specs": "^0.5.0",
-						"make-fetch-happen": "^15.0.3",
-						"proc-log": "^6.1.0",
-						"promise-retry": "^2.0.1"
+						"make-fetch-happen": "^15.0.4",
+						"proc-log": "^6.1.0"
 					}
 				},
 				"@sigstore/tuf": {
-					"version": "4.0.1",
+					"version": "4.0.2",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -12008,7 +11971,7 @@
 					"dev": true
 				},
 				"brace-expansion": {
-					"version": "5.0.3",
+					"version": "5.0.5",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -12016,7 +11979,7 @@
 					}
 				},
 				"cacache": {
-					"version": "20.0.3",
+					"version": "20.0.4",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -12029,8 +11992,7 @@
 						"minipass-flush": "^1.0.5",
 						"minipass-pipeline": "^1.2.4",
 						"p-map": "^7.0.2",
-						"ssri": "^13.0.0",
-						"unique-filename": "^5.0.0"
+						"ssri": "^13.0.0"
 					}
 				},
 				"chalk": {
@@ -12049,7 +12011,7 @@
 					"dev": true
 				},
 				"cidr-regex": {
-					"version": "5.0.3",
+					"version": "5.0.4",
 					"bundled": true,
 					"dev": true
 				},
@@ -12077,7 +12039,7 @@
 					}
 				},
 				"diff": {
-					"version": "8.0.3",
+					"version": "8.0.4",
 					"bundled": true,
 					"dev": true
 				},
@@ -12088,7 +12050,6 @@
 				},
 				"err-code": {
 					"version": "2.0.3",
-					"bundled": true,
 					"dev": true
 				},
 				"exponential-backoff": {
@@ -12174,7 +12135,6 @@
 				},
 				"imurmurhash": {
 					"version": "0.1.4",
-					"bundled": true,
 					"dev": true
 				},
 				"ini": {
@@ -12201,11 +12161,11 @@
 					"dev": true
 				},
 				"is-cidr": {
-					"version": "6.0.3",
+					"version": "6.0.4",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"cidr-regex": "^5.0.1"
+						"cidr-regex": "^5.0.4"
 					}
 				},
 				"isexe": {
@@ -12248,11 +12208,11 @@
 					}
 				},
 				"libnpmdiff": {
-					"version": "8.1.3",
+					"version": "8.1.6",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"@npmcli/arborist": "^9.4.0",
+						"@npmcli/arborist": "^9.4.3",
 						"@npmcli/installed-package-contents": "^4.0.0",
 						"binary-extensions": "^3.0.0",
 						"diff": "^8.0.2",
@@ -12263,12 +12223,12 @@
 					}
 				},
 				"libnpmexec": {
-					"version": "10.2.3",
+					"version": "10.2.6",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"@gar/promise-retry": "^1.0.0",
-						"@npmcli/arborist": "^9.4.0",
+						"@npmcli/arborist": "^9.4.3",
 						"@npmcli/package-json": "^7.0.0",
 						"@npmcli/run-script": "^10.0.0",
 						"ci-info": "^4.0.0",
@@ -12282,11 +12242,11 @@
 					}
 				},
 				"libnpmfund": {
-					"version": "7.0.17",
+					"version": "7.0.20",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"@npmcli/arborist": "^9.4.0"
+						"@npmcli/arborist": "^9.4.3"
 					}
 				},
 				"libnpmorg": {
@@ -12299,11 +12259,11 @@
 					}
 				},
 				"libnpmpack": {
-					"version": "9.1.3",
+					"version": "9.1.6",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"@npmcli/arborist": "^9.4.0",
+						"@npmcli/arborist": "^9.4.3",
 						"@npmcli/run-script": "^10.0.0",
 						"npm-package-arg": "^13.0.0",
 						"pacote": "^21.0.2"
@@ -12354,17 +12314,18 @@
 					}
 				},
 				"lru-cache": {
-					"version": "11.2.6",
+					"version": "11.3.5",
 					"bundled": true,
 					"dev": true
 				},
 				"make-fetch-happen": {
-					"version": "15.0.4",
+					"version": "15.0.5",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"@gar/promise-retry": "^1.0.0",
 						"@npmcli/agent": "^4.0.0",
+						"@npmcli/redact": "^4.0.0",
 						"cacache": "^20.0.1",
 						"http-cache-semantics": "^4.1.1",
 						"minipass": "^7.0.2",
@@ -12377,11 +12338,11 @@
 					}
 				},
 				"minimatch": {
-					"version": "10.2.2",
+					"version": "10.2.5",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"brace-expansion": "^5.0.2"
+						"brace-expansion": "^5.0.5"
 					}
 				},
 				"minipass": {
@@ -12409,26 +12370,11 @@
 					}
 				},
 				"minipass-flush": {
-					"version": "1.0.5",
+					"version": "1.0.6",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"minipass": "^3.0.0"
-					},
-					"dependencies": {
-						"minipass": {
-							"version": "3.3.6",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"yallist": "^4.0.0"
-							}
-						},
-						"yallist": {
-							"version": "4.0.0",
-							"bundled": true,
-							"dev": true
-						}
+						"minipass": "^7.1.3"
 					}
 				},
 				"minipass-pipeline": {
@@ -12486,19 +12432,19 @@
 					"dev": true
 				},
 				"node-gyp": {
-					"version": "12.2.0",
+					"version": "12.3.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"env-paths": "^2.2.0",
 						"exponential-backoff": "^3.1.1",
 						"graceful-fs": "^4.2.6",
-						"make-fetch-happen": "^15.0.0",
 						"nopt": "^9.0.0",
 						"proc-log": "^6.0.0",
 						"semver": "^7.3.5",
 						"tar": "^7.5.4",
 						"tinyglobby": "^0.2.12",
+						"undici": "^6.25.0",
 						"which": "^6.0.0"
 					}
 				},
@@ -12602,7 +12548,7 @@
 					"dev": true
 				},
 				"pacote": {
-					"version": "21.4.0",
+					"version": "21.5.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -12675,7 +12621,6 @@
 				},
 				"promise-retry": {
 					"version": "2.0.1",
-					"bundled": true,
 					"dev": true,
 					"requires": {
 						"err-code": "^2.0.2",
@@ -12710,7 +12655,6 @@
 				},
 				"retry": {
 					"version": "0.12.0",
-					"bundled": true,
 					"dev": true
 				},
 				"safer-buffer": {
@@ -12799,7 +12743,7 @@
 					"dev": true
 				},
 				"tar": {
-					"version": "7.5.9",
+					"version": "7.5.13",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -12821,12 +12765,12 @@
 					"dev": true
 				},
 				"tinyglobby": {
-					"version": "0.2.15",
+					"version": "0.2.16",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"fdir": "^6.5.0",
-						"picomatch": "^4.0.3"
+						"picomatch": "^4.0.4"
 					},
 					"dependencies": {
 						"fdir": {
@@ -12836,7 +12780,7 @@
 							"requires": {}
 						},
 						"picomatch": {
-							"version": "4.0.3",
+							"version": "4.0.4",
 							"bundled": true,
 							"dev": true
 						}
@@ -12857,9 +12801,13 @@
 						"make-fetch-happen": "^15.0.1"
 					}
 				},
+				"undici": {
+					"version": "6.25.0",
+					"bundled": true,
+					"dev": true
+				},
 				"unique-filename": {
 					"version": "5.0.0",
-					"bundled": true,
 					"dev": true,
 					"requires": {
 						"unique-slug": "^6.0.0"
@@ -12867,7 +12815,6 @@
 				},
 				"unique-slug": {
 					"version": "6.0.0",
-					"bundled": true,
 					"dev": true,
 					"requires": {
 						"imurmurhash": "^0.1.4"
@@ -12897,11 +12844,10 @@
 					}
 				},
 				"write-file-atomic": {
-					"version": "7.0.0",
+					"version": "7.0.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"imurmurhash": "^0.1.4",
 						"signal-exit": "^4.0.1"
 					}
 				},
@@ -13129,9 +13075,9 @@
 			"dev": true
 		},
 		"picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+			"integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
 			"dev": true
 		},
 		"pify": {
@@ -13962,9 +13908,9 @@
 					"requires": {}
 				},
 				"picomatch": {
-					"version": "4.0.3",
-					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-					"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+					"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 					"dev": true
 				}
 			}
@@ -14032,9 +13978,9 @@
 			"optional": true
 		},
 		"undici": {
-			"version": "7.22.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-			"integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+			"integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
 			"dev": true
 		},
 		"undici-types": {


### PR DESCRIPTION
## Summary

Cleans the security tab in one sweep — three things, all low-risk:

### 1. Dependabot — 20 open alerts cleared
Ran \`npm audit fix\`. Bumped transitive devDeps (handlebars, undici, lodash, lodash-es, picomatch, flatted). All alerts were under build/release tooling.

- \`package.json\` is unchanged — the project has no runtime \`dependencies\`, only the lock file moves.
- \`npm audit --omit=dev\` was already \`0\` before this change → no runtime risk to plugin users; the published \`main.js\` bundle is built from \`src/\` only and pulls none of these packages.
- \`npm audit\` after the fix: **0 vulnerabilities**.
- Production build verified clean (\`npm run build\` → \`build/main.js\` produced).

### 2. Code Scanning — 1 open alert cleared
Added explicit \`permissions:\` to \`.github/workflows/release.yml\` (least-privilege).

- Workflow default: \`contents: read\`
- Release job elevated to: \`contents: write\` (tags, releases), \`issues: write\` and \`pull-requests: write\` (semantic-release closing comments)

### 3. TASKS.md
- Drops **TD-5** — actions are already on \`v4\` (since \`dffa46a\`); the entry was stale.
- Adds an entry under *Pending Confirmation* documenting the cleanup.

## Test plan
- [ ] CI: release.yml runs successfully on merge with the new permissions block (semantic-release can still push tags, create the GitHub Release, and comment on closed issues / PRs)
- [ ] Dependabot alerts auto-close after merge
- [ ] Code Scanning alert auto-closes after merge
- [ ] No change to published plugin behaviour (bundle unchanged)