### PR TITLE
chore: dep audit cleanup + manifest guideline fixes

### DIFF
--- a/Dynbedded/.obsidian/plugins/obsidian-dynbedded/manifest.json
+++ b/Dynbedded/.obsidian/plugins/obsidian-dynbedded/manifest.json
@@ -3,8 +3,8 @@
 	"name": "Dynbedded",
 	"version": "1.2.2",
 	"minAppVersion": "1.4.0",
-	"description": "Dynamic Embeds for Obsidian.md",
-	"author": "Marcus Breiden <marcus@mmomm.org>",
+	"description": "Embed files or header sections with optional date-based filename substitution.",
+	"author": "Marcus Breiden",
 	"authorUrl": "https://www.mmomm.org",
 	"isDesktopOnly": false
 }

--- a/manifest.json
+++ b/manifest.json
@@ -3,8 +3,8 @@
 	"name": "Dynbedded",
 	"version": "1.2.3",
 	"minAppVersion": "1.4.0",
-	"description": "Dynamic Embeds for Obsidian.md",
-	"author": "Marcus Breiden <marcus@mmomm.org>",
+	"description": "Embed files or header sections with optional date-based filename substitution.",
+	"author": "Marcus Breiden",
 	"authorUrl": "https://www.mmomm.org",
 	"isDesktopOnly": false
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-dynbedded",
-	"version": "1.2.2",
+	"version": "1.2.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-dynbedded",
-			"version": "1.2.2",
+			"version": "1.2.3",
 			"license": "GPLv3",
 			"devDependencies": {
 				"@semantic-release/changelog": "^6.0.3",
@@ -5351,11 +5351,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/npm/node_modules/err-code": {
-			"version": "2.0.3",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/npm/node_modules/exponential-backoff": {
 			"version": "3.1.3",
 			"dev": true,
@@ -5477,14 +5472,6 @@
 			},
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/npm/node_modules/imurmurhash": {
-			"version": "0.1.4",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.8.19"
 			}
 		},
 		"node_modules/npm/node_modules/ini": {
@@ -6199,18 +6186,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/npm/node_modules/promise-retry": {
-			"version": "2.0.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"err-code": "^2.0.2",
-				"retry": "^0.12.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/npm/node_modules/promzard": {
 			"version": "3.0.1",
 			"dev": true,
@@ -6250,14 +6225,6 @@
 			"license": "ISC",
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/npm/node_modules/retry": {
-			"version": "0.12.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
 			}
 		},
 		"node_modules/npm/node_modules/safer-buffer": {
@@ -6495,28 +6462,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=18.17"
-			}
-		},
-		"node_modules/npm/node_modules/unique-filename": {
-			"version": "5.0.0",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"unique-slug": "^6.0.0"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
-			}
-		},
-		"node_modules/npm/node_modules/unique-slug": {
-			"version": "6.0.0",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"imurmurhash": "^0.1.4"
-			},
-			"engines": {
-				"node": "^20.17.0 || >=22.9.0"
 			}
 		},
 		"node_modules/npm/node_modules/util-deprecate": {
@@ -12048,10 +11993,6 @@
 					"bundled": true,
 					"dev": true
 				},
-				"err-code": {
-					"version": "2.0.3",
-					"dev": true
-				},
 				"exponential-backoff": {
 					"version": "3.1.3",
 					"bundled": true,
@@ -12132,10 +12073,6 @@
 					"requires": {
 						"minimatch": "^10.0.3"
 					}
-				},
-				"imurmurhash": {
-					"version": "0.1.4",
-					"dev": true
 				},
 				"ini": {
 					"version": "6.0.0",
@@ -12619,14 +12556,6 @@
 					"bundled": true,
 					"dev": true
 				},
-				"promise-retry": {
-					"version": "2.0.1",
-					"dev": true,
-					"requires": {
-						"err-code": "^2.0.2",
-						"retry": "^0.12.0"
-					}
-				},
 				"promzard": {
 					"version": "3.0.1",
 					"bundled": true,
@@ -12651,10 +12580,6 @@
 				"read-cmd-shim": {
 					"version": "6.0.0",
 					"bundled": true,
-					"dev": true
-				},
-				"retry": {
-					"version": "0.12.0",
 					"dev": true
 				},
 				"safer-buffer": {
@@ -12805,20 +12730,6 @@
 					"version": "6.25.0",
 					"bundled": true,
 					"dev": true
-				},
-				"unique-filename": {
-					"version": "5.0.0",
-					"dev": true,
-					"requires": {
-						"unique-slug": "^6.0.0"
-					}
-				},
-				"unique-slug": {
-					"version": "6.0.0",
-					"dev": true,
-					"requires": {
-						"imurmurhash": "^0.1.4"
-					}
 				},
 				"util-deprecate": {
 					"version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-	"author": "Marcus Breiden <marcus@mmomm.org",
+	"author": "Marcus Breiden",
 	"repository": "https://github.com/MMoMM-org/obsidian-dynbedded.git",
 	"dependencies": {},
-	"description": "Dynamic Embeds for Obsidian.md",
+	"description": "Embed files or header sections with optional date-based filename substitution.",
 	"devDependencies": {
 		"@types/node": "^22.0.0",
 		"@typescript-eslint/eslint-plugin": "^8.0.0",


### PR DESCRIPTION
## Summary

Two unrelated chores bundled because they're both pre-release hygiene:

### 1. `chore(deps)`: clear 31 of 32 npm audit warnings

- `npm update semantic-release @semantic-release/npm` regenerated `package-lock.json` and pulled the latest bundled npm, reducing moderate-severity advisories from **32 → 1**.
- Only `package-lock.json` changed — no `package.json` range bumps.

**Remaining vulnerability — GHSA-v2v4-37r5-5v8g (`ip-address` XSS):** bundled **inside** `npm@11.14.1`, which is bundled inside `@semantic-release/npm`. Cannot be patched via lockfile or `overrides`. Waits on an upstream npm release shipping a patched `ip-address`. Dev-only — no end-user exposure.

### 2. `chore(manifest)`: satisfy Obsidian community-plugin guidelines

Three findings from the official review checklist:

- **Author** must not contain an email — dropped `<marcus@mmomm.org>` on `manifest.json` and `package.json`. (`package.json` also had a malformed value missing the closing `>`.)
- **Description** must end with punctuation — added trailing period.
- **Description** must not contain the word "Obsidian".

New description: `"Embed files or header sections with optional date-based filename substitution."`

Also synced the tracked test-vault manifest at `Dynbedded/.obsidian/plugins/obsidian-dynbedded/manifest.json`.

## Test plan

- [x] `npm run build` passes (`tsc -noEmit` clean, esbuild emits 13.8 kB `build/main.js`)
- [x] `npm audit` reports 1 moderate (was 32)
- [x] All three JSON files parse cleanly
- [ ] CodeQL on PR
- [ ] Release workflow dry-run on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)