### PR TITLE
chore(deps): bump bundled npm to clear ip-address XSS alert

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "claudeMdExcludes": [
+    "claude-docker-home/CLAUDE.md"
+  ]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -227,3 +227,8 @@ dist
 .pnp.*
 
 /.idea/sonarlint/issuestore/index.pb
+/claude-docker/
+/claude-docker-home/
+/begin-code.sh
+.mcp.json
+/generated-images/

--- a/package-lock.json
+++ b/package-lock.json
@@ -4606,9 +4606,9 @@
 			}
 		},
 		"node_modules/npm": {
-			"version": "11.13.0",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-11.13.0.tgz",
-			"integrity": "sha512-cRmhaghDWA1lFgl3Ug4/VxDJdPBK/U+tNtnrl9kXunFqhWw1x4xL5txkNn7qzPuVfvXOmXyjHpMwsuk2uisbkg==",
+			"version": "11.14.1",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-11.14.1.tgz",
+			"integrity": "sha512-aopNZ0eEl6LbxoFcrXLmTEPzNBNxfiQnVgR9RmJBqzm+5h5pFoOmRljpRJbsXxocBeSl7GLcx3MoDf2UlEOjZw==",
 			"bundleDependencies": [
 				"@isaacs/string-locale-compare",
 				"@npmcli/arborist",
@@ -4687,8 +4687,8 @@
 			],
 			"dependencies": {
 				"@isaacs/string-locale-compare": "^1.1.0",
-				"@npmcli/arborist": "^9.4.3",
-				"@npmcli/config": "^10.8.1",
+				"@npmcli/arborist": "^9.5.0",
+				"@npmcli/config": "^10.9.0",
 				"@npmcli/fs": "^5.0.0",
 				"@npmcli/map-workspaces": "^5.0.3",
 				"@npmcli/metavuln-calculator": "^9.0.3",
@@ -4712,11 +4712,11 @@
 				"is-cidr": "^6.0.4",
 				"json-parse-even-better-errors": "^5.0.0",
 				"libnpmaccess": "^10.0.3",
-				"libnpmdiff": "^8.1.6",
-				"libnpmexec": "^10.2.6",
-				"libnpmfund": "^7.0.20",
+				"libnpmdiff": "^8.1.7",
+				"libnpmexec": "^10.2.7",
+				"libnpmfund": "^7.0.21",
 				"libnpmorg": "^8.0.1",
-				"libnpmpack": "^9.1.6",
+				"libnpmpack": "^9.1.7",
 				"libnpmpublish": "^11.1.3",
 				"libnpmsearch": "^9.0.1",
 				"libnpmteam": "^8.0.2",
@@ -4816,7 +4816,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/arborist": {
-			"version": "9.4.3",
+			"version": "9.5.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -4864,7 +4864,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/config": {
-			"version": "10.8.1",
+			"version": "10.9.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -5278,7 +5278,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/cidr-regex": {
-			"version": "5.0.4",
+			"version": "5.0.5",
 			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause",
@@ -5501,7 +5501,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/ip-address": {
-			"version": "10.1.0",
+			"version": "10.1.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -5583,12 +5583,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmdiff": {
-			"version": "8.1.6",
+			"version": "8.1.7",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^9.4.3",
+				"@npmcli/arborist": "^9.5.0",
 				"@npmcli/installed-package-contents": "^4.0.0",
 				"binary-extensions": "^3.0.0",
 				"diff": "^8.0.2",
@@ -5602,13 +5602,13 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmexec": {
-			"version": "10.2.6",
+			"version": "10.2.7",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"@gar/promise-retry": "^1.0.0",
-				"@npmcli/arborist": "^9.4.3",
+				"@npmcli/arborist": "^9.5.0",
 				"@npmcli/package-json": "^7.0.0",
 				"@npmcli/run-script": "^10.0.0",
 				"ci-info": "^4.0.0",
@@ -5625,12 +5625,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmfund": {
-			"version": "7.0.20",
+			"version": "7.0.21",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^9.4.3"
+				"@npmcli/arborist": "^9.5.0"
 			},
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
@@ -5650,12 +5650,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmpack": {
-			"version": "9.1.6",
+			"version": "9.1.7",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^9.4.3",
+				"@npmcli/arborist": "^9.5.0",
 				"@npmcli/run-script": "^10.0.0",
 				"npm-package-arg": "^13.0.0",
 				"pacote": "^21.0.2"
@@ -6286,12 +6286,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/socks": {
-			"version": "2.8.7",
+			"version": "2.8.8",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
-				"ip-address": "^10.0.1",
+				"ip-address": "^10.1.1",
 				"smart-buffer": "^4.2.0"
 			},
 			"engines": {
@@ -11539,14 +11539,14 @@
 			"dev": true
 		},
 		"npm": {
-			"version": "11.13.0",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-11.13.0.tgz",
-			"integrity": "sha512-cRmhaghDWA1lFgl3Ug4/VxDJdPBK/U+tNtnrl9kXunFqhWw1x4xL5txkNn7qzPuVfvXOmXyjHpMwsuk2uisbkg==",
+			"version": "11.14.1",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-11.14.1.tgz",
+			"integrity": "sha512-aopNZ0eEl6LbxoFcrXLmTEPzNBNxfiQnVgR9RmJBqzm+5h5pFoOmRljpRJbsXxocBeSl7GLcx3MoDf2UlEOjZw==",
 			"dev": true,
 			"requires": {
 				"@isaacs/string-locale-compare": "^1.1.0",
-				"@npmcli/arborist": "^9.4.3",
-				"@npmcli/config": "^10.8.1",
+				"@npmcli/arborist": "^9.5.0",
+				"@npmcli/config": "^10.9.0",
 				"@npmcli/fs": "^5.0.0",
 				"@npmcli/map-workspaces": "^5.0.3",
 				"@npmcli/metavuln-calculator": "^9.0.3",
@@ -11570,11 +11570,11 @@
 				"is-cidr": "^6.0.4",
 				"json-parse-even-better-errors": "^5.0.0",
 				"libnpmaccess": "^10.0.3",
-				"libnpmdiff": "^8.1.6",
-				"libnpmexec": "^10.2.6",
-				"libnpmfund": "^7.0.20",
+				"libnpmdiff": "^8.1.7",
+				"libnpmexec": "^10.2.7",
+				"libnpmfund": "^7.0.21",
 				"libnpmorg": "^8.0.1",
-				"libnpmpack": "^9.1.6",
+				"libnpmpack": "^9.1.7",
 				"libnpmpublish": "^11.1.3",
 				"libnpmsearch": "^9.0.1",
 				"libnpmteam": "^8.0.2",
@@ -11642,7 +11642,7 @@
 					}
 				},
 				"@npmcli/arborist": {
-					"version": "9.4.3",
+					"version": "9.5.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -11683,7 +11683,7 @@
 					}
 				},
 				"@npmcli/config": {
-					"version": "10.8.1",
+					"version": "10.9.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -11956,7 +11956,7 @@
 					"dev": true
 				},
 				"cidr-regex": {
-					"version": "5.0.4",
+					"version": "5.0.5",
 					"bundled": true,
 					"dev": true
 				},
@@ -12093,7 +12093,7 @@
 					}
 				},
 				"ip-address": {
-					"version": "10.1.0",
+					"version": "10.1.1",
 					"bundled": true,
 					"dev": true
 				},
@@ -12145,11 +12145,11 @@
 					}
 				},
 				"libnpmdiff": {
-					"version": "8.1.6",
+					"version": "8.1.7",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"@npmcli/arborist": "^9.4.3",
+						"@npmcli/arborist": "^9.5.0",
 						"@npmcli/installed-package-contents": "^4.0.0",
 						"binary-extensions": "^3.0.0",
 						"diff": "^8.0.2",
@@ -12160,12 +12160,12 @@
 					}
 				},
 				"libnpmexec": {
-					"version": "10.2.6",
+					"version": "10.2.7",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"@gar/promise-retry": "^1.0.0",
-						"@npmcli/arborist": "^9.4.3",
+						"@npmcli/arborist": "^9.5.0",
 						"@npmcli/package-json": "^7.0.0",
 						"@npmcli/run-script": "^10.0.0",
 						"ci-info": "^4.0.0",
@@ -12179,11 +12179,11 @@
 					}
 				},
 				"libnpmfund": {
-					"version": "7.0.20",
+					"version": "7.0.21",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"@npmcli/arborist": "^9.4.3"
+						"@npmcli/arborist": "^9.5.0"
 					}
 				},
 				"libnpmorg": {
@@ -12196,11 +12196,11 @@
 					}
 				},
 				"libnpmpack": {
-					"version": "9.1.6",
+					"version": "9.1.7",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"@npmcli/arborist": "^9.4.3",
+						"@npmcli/arborist": "^9.5.0",
 						"@npmcli/run-script": "^10.0.0",
 						"npm-package-arg": "^13.0.0",
 						"pacote": "^21.0.2"
@@ -12617,11 +12617,11 @@
 					"dev": true
 				},
 				"socks": {
-					"version": "2.8.7",
+					"version": "2.8.8",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ip-address": "^10.0.1",
+						"ip-address": "^10.1.1",
 						"smart-buffer": "^4.2.0"
 					}
 				},


### PR DESCRIPTION
## Summary

Resolves Dependabot alert [#36](https://github.com/MMoMM-org/obsidian-dynbedded/security/dependabot/36) — GHSA-v2v4-37r5-5v8g / CVE-2026-42338, medium severity.

- **Package:** `ip-address` (devDependency, transitive, bundled inside `npm`)
- **Path:** `semantic-release@25.0.3` → `@semantic-release/npm@13.1.5` → `npm@11.13.0` (bundled) → `ip-address@10.1.0`
- **Fix:** `npm update npm --package-lock-only` bumps the bundled npm to `11.14.1`, which ships `ip-address@10.1.1` (verified by unpacking the tarball).

`npm audit` now reports `0 vulnerabilities` (both with and without `--omit=dev`).

## Impact

DevDependency only — runtime `dependencies` is empty, so nothing ships to end-user plugins. The vulnerable code paths in `ip-address` (`Address6.group()`, `Address6.link()`, `AddressError.parseMessage`) require feeding untrusted input through `Address6` and rendering the result as HTML; neither `semantic-release` nor the `npm` CLI does that. So the alert was theoretical for this project — this PR just clears the noise.

## Test plan

- [x] `npm audit` → 0 vulnerabilities
- [x] `npm audit --omit=dev` → 0 vulnerabilities
- [x] `node_modules/npm` resolves to `11.14.1` in the lockfile
- [ ] After merge: GitHub closes Dependabot alert #36 automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)