### PR TITLE
chore(docs): move shipped tasks to Done sections (v1.2.2 → v1.3.1)

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -14,41 +14,7 @@ Sourced from [GitHub Issues](https://github.com/MMoMM-org/obsidian-dynbedded/iss
 
 ## Pending Confirmation
 
-### Plugin review compliance — code, settings, release pipeline
-Bundle of fixes addressing Obsidian community-plugin review warnings:
-
-- `DynbeddedProcessor.ts` — TFile concatenated as string rendered as `[object Object]`; now uses `matchingFile.path`.
-- `DynbeddedProcessor.ts` / `DynbeddedBlock.ts` — `MarkdownRenderer.render` now receives the per-block `MarkdownRenderChild` instead of the plugin instance, so registered children are released when the block unloads (memory-leak warning).
-- `DynbeddedBlock.ts` — `onload()` no longer returns a Promise (Obsidian's Component contract is void); same for the `setInterval` re-render callback.
-- `DynbeddedSettingTab.ts` — `addEventListener('blur', async …)` replaced with `void` dispatch; section headings switched to `new Setting().setHeading()`; plugin banner h1/h2 replaced with structured divs styled via `--h1-size` / `--h2-size`.
-- `styles.css` — dropped `!important` on `.dynbedded-disabled-input` in favour of `input.dynbedded-disabled-input` specificity; added `.dynbedded-settings-banner-*` rules.
-- `esbuild.config.mjs` / `package.json` — replaced `builtin-modules` dependency with Node's `node:module` `builtinModules`.
-- `package.json` / `createZip.sh` — removed zip release asset (Obsidian only consumes main.js/manifest.json/styles.css) and the `@semantic-release/exec` step / script that built it.
-- `.github/workflows/release.yml` — added `id-token: write` + `attestations: write` permissions and an `actions/attest-build-provenance` step so release assets carry GitHub artifact attestations.
-- `.gitignore` / `Dynbedded/.obsidian/plugins/` — untracked the three third-party test plugins (buttons, dataview, obsidian-tasks-plugin) that were producing unrelated lint warnings during review; hot-reload stays in tree.
-
-**Where:** `src/DynbeddedProcessor.ts`, `src/DynbeddedBlock.ts`, `src/DynbeddedSettingTab.ts`, `styles.css`, `esbuild.config.mjs`, `package.json`, `.github/workflows/release.yml`, `.gitignore`
-
-**Complexity: M**
-
-### #13 — Refresh Interval Seconds can't be changed
-Two parts:
-
-1. **Disabled state on Windows (released in 1.2.2):** `Setting.setDisabled()` only toggles the `is-disabled` CSS class on the wrapper; it does not set the native HTML `disabled` attribute on the input. Fixed by also calling `TextComponent.setDisabled()` so `inputEl.disabled` is browser-enforced.
-
-2. **Visual feedback when gated:** Field was technically disabled when Auto-Refresh was off, but the styling was too subtle on some platforms (Windows / Electron) — users couldn't tell the field was gated by the toggle and reported it as broken. Added an explicit description swap (*"Enable Auto-Refresh above to change this value"*) plus a CSS rule that lowers opacity and shows a `not-allowed` cursor on the disabled input.
-
-**Where:** `src/DynbeddedSettingTab.ts`, `styles.css`
-
-**Complexity: XS**
-
-### Security & permissions cleanup
-- Resolved 20 open Dependabot alerts (handlebars / undici / lodash / picomatch / flatted) by running `npm audit fix`. All were transitive devDependencies of the build/release tooling — `npm audit --omit=dev` was already 0. No runtime impact on the published plugin (`dependencies: {}`); only the lock file changed.
-- Closed the open Code Scanning alert by adding an explicit `permissions:` block to `.github/workflows/release.yml`: workflow-default `contents: read`, with the release job elevated to `contents: write`, `issues: write`, and `pull-requests: write` for semantic-release.
-
-**Where:** `package-lock.json`, `.github/workflows/release.yml`
-
-**Complexity: XS**
+*(none)*
 
 ---
 
@@ -84,6 +50,31 @@ Allow `{{DWed}}` to resolve to this week's Wednesday, and `{{D-1Wed}}` to last w
 **Complexity: Low**
 
 ---
+
+## Done (released in v1.3.1)
+
+| Task | Commit |
+|------|--------|
+| ESLint 9 + eslint-plugin-obsidianmd migration; sentence-case labels; "Plugin Settings"→"Embedding" / "Developer Settings"→"Logging" heading renames; `console.log`→`error`/`debug`; typed `loadSettings` | `abfc0bd` (#21) |
+
+## Done (released in v1.3.0)
+
+| Task | Commit |
+|------|--------|
+| Plugin review compliance bundle — code, settings, release pipeline (TFile path, render-child component, void onload/blur, setHeading/banner, styles.css `!important` removed, builtin-modules→`node:module`, zip asset dropped, build-provenance attestations, untracked third-party test plugins) | `c369ecb` (#19) |
+| Security & permissions cleanup — 20 Dependabot alerts cleared + workflow `permissions:` block | `9a9e884` (#17) |
+
+## Done (released in v1.2.3)
+
+| Task | Commit |
+|------|--------|
+| #13 — Refresh Interval Seconds: visual feedback when gated by Auto-Refresh | `1f0498a` |
+
+## Done (released in v1.2.2)
+
+| Task | Commit |
+|------|--------|
+| #13 — Refresh Interval Seconds: native HTML `disabled` attribute on Windows | `6c88390` |
 
 ## Done (released in v1.2.0)
 


### PR DESCRIPTION
## Summary

- Empties **Pending Confirmation** in TASKS.md now that all the work sitting there has shipped
- Records each task under its actual release tag (v1.2.2, v1.2.3, v1.3.0, v1.3.1)

## Why now

Following the project's task-lifecycle convention (*"set tasks to Pending Confirmation when committed, Done when a release is published"*), the bookkeeping had drifted: #13's two-part fix had been Pending Confirmation since v1.2.2 / v1.2.3 even though those tags shipped weeks ago, and v1.3.0 + v1.3.1 just landed today without their entries being moved.

## Changes

**Moved out of Pending Confirmation:**
- *Plugin review compliance bundle* → Done in **v1.3.0** (PR #19, `c369ecb`)
- *Security & permissions cleanup* → Done in **v1.3.0** (PR #17, `9a9e884`)
- *#13 — Refresh Interval Seconds (visual feedback)* → Done in **v1.2.3** (`1f0498a`)
- *#13 — Refresh Interval Seconds (disabled state)* → Done in **v1.2.2** (`6c88390`)

**New entry:**
- Done in **v1.3.1** — ESLint 9 migration + sentence-case labels, "Plugin Settings"→"Embedding" / "Developer Settings"→"Logging" heading renames, `console.log`→`error`/`debug`, typed `loadSettings` (PR #21, `abfc0bd`)

## Test plan

- [x] Pending Confirmation section reads `*(none)*`
- [x] Every Done section has a matching git tag
- No code touched — TASKS.md only, no build/lint impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)