### PR TITLE
feat: add fundingUrl to manifest, fix FUNDING.yml github handle

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,6 +1,6 @@
 # These are supported funding model platforms
 
-github: [MMoMM-Marcus]
+github: [MMoMM-org]
 patreon: # Replace with a single Patreon username
 ko_fi: mmomm
 custom: ["https://www.buymeacoffee.com/mmomm"]# Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']

--- a/manifest.json
+++ b/manifest.json
@@ -6,5 +6,9 @@
 	"description": "Embed files or header sections with optional date-based filename substitution.",
 	"author": "Marcus Breiden",
 	"authorUrl": "https://www.mmomm.org",
+	"fundingUrl": {
+		"Buy Me a Coffee": "https://ko-fi.com/mmomm",
+		"GitHub Sponsor": "https://github.com/sponsors/MMoMM-org"
+	},
 	"isDesktopOnly": false
 }


### PR DESCRIPTION
## Summary
- Adds `fundingUrl` (Ko-fi + GitHub Sponsors) to `manifest.json`, mirroring the sponsoring setup in [obsidian-archivist](https://github.com/MMoMM-org/obsidian-archivist). Obsidian's plugin pane will now surface both funding links next to Dynbedded.
- Fixes `.github/FUNDING.yml` — the `github:` entry pointed at `MMoMM-Marcus` which is a 404. Corrected to `MMoMM-org` (the org with the active sponsor page).

## Test plan
- [ ] After merge + release, open Obsidian → Settings → Community plugins → Dynbedded and confirm both funding entries are shown
- [ ] Visit https://github.com/MMoMM-org/obsidian-dynbedded — confirm the "Sponsor" button appears in the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)