### PR TITLE
chore(docs): drop stale 'untested release pipeline' note

### DIFF
--- a/.claude/rules/project-context.md
+++ b/.claude/rules/project-context.md
@@ -34,22 +34,6 @@ Use `chore:` for changes outside the plugin source (test vault files, build arti
 
 **Push only when a feature or fix is ready to release.** Intermediate `chore:` commits are batched and pushed together with the next real feature/fix.
 
-## Pending: Untested Release Pipeline Refactor (commit dffa46a)
-
-Commit `dffa46a` (2026-03-13) implements a release pipeline cleanup but has **NOT been pushed or tested**. It must ship together with the next `fix:` or `feat:` commit.
-
-**What was changed:**
-- `build/` removed from git tracking (`git rm --cached`) and added to `.gitignore` — build artifacts no longer committed to the repo
-- `esbuild.config.mjs` — copy plugin disabled for production mode (dev/devbuild still copy manifest.json + styles.css)
-- `package.json` — `prepareCmd` removed from `@semantic-release/exec` (was causing double-execution of version-bump); `@semantic-release/git` assets trimmed to metadata only; `@semantic-release/github` uses explicit asset labels
-- `createZip.sh` — hardened with `rm -rf $1` before `mkdir`
-- `.github/workflows/release.yml` — bumped `actions/checkout` and `actions/setup-node` from v2 → v4
-
-**What to verify on first push:**
-- CI builds correctly and `build/` is populated at publish time
-- GitHub Release assets (`main.js`, `manifest.json`, `styles.css`, zip) are uploaded correctly
-- Release commit contains only `manifest.json`, `versions.json`, `Changelog.md`, `package.json` (no compiled JS)
-
 ## TASKS.md Lifecycle
 
 Only committed-but-unreleased tasks belong in **Pending Confirmation**. Newly created GitHub issues for future features (not yet implemented) stay in **Open** or **Future Features** — they do not move to Pending Confirmation.


### PR DESCRIPTION
## Summary
- Removes the *Pending: Untested Release Pipeline Refactor (commit dffa46a)* section from `.claude/rules/project-context.md`.
- The refactor was verified on release **1.4.0** (PR #24): the release commit `ef22eb8` contains only metadata (manifest.json, versions.json, Changelog.md, package.json, FUNDING.yml) and all three release assets (`main.js`, `manifest.json`, `styles.css`) were uploaded correctly.

## Test plan
- [ ] No code change — docs only. Confirm CI is green and merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)