### PR TITLE
chore: bump dev deps to clear Dependabot alerts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ The pre-refactor single-pass logic now lives split across the parser (link/heade
 ## Toolchain
 
 - **TypeScript 5** — type checking only (`tsc -noEmit`); esbuild does the actual bundling
-- **esbuild 0.27** — bundles to CJS, target ES2018; watch mode uses `esbuild.context()` API
+- **esbuild 0.28** — bundles to CJS, target ES2018; watch mode uses `esbuild.context()` API
 - **eslint 8 + @typescript-eslint 8** — linting (`.eslintrc`)
 - **stylelint + stylelint-no-unsupported-browser-features** — CSS browser-compat lint that mirrors the Obsidian community-plugin review bot (doiuse + browserslist + caniuse). Run via `npm run lint` (chained after eslint) or `npm run lint:css`. The `browserslist` floor in `package.json` is pinned to **`chrome 114`** — this is the Chromium of `minAppVersion` 1.4.0 (Obsidian 1.4.x → Electron 25 → Chromium 114). Raise it only when `minAppVersion` rises; pinning too high hides features Obsidian's older Chromium can't run, pinning too low produces noise on long-stable features (grid/flex/gap). With `ignorePartialSupport: false`, partially-supported features (e.g. the `text-decoration` shorthand carrying a line-style like `underline dotted`/`wavy`) are flagged — these slip past ESLint, which never lints CSS. Prefer `border-bottom` (inherits currentColor) over `text-decoration` for underline-style cues.
 - **semantic-release 25** — automated releases via GitHub Actions (`.github/workflows/release.yml`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-dynbedded",
-	"version": "1.4.0",
+	"version": "1.5.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-dynbedded",
-			"version": "1.4.0",
+			"version": "1.5.0",
 			"license": "GPLv3",
 			"devDependencies": {
 				"@eslint/js": "9.39.4",
@@ -15,7 +15,7 @@
 				"@semantic-release/git": "^10.0.1",
 				"@semantic-release/release-notes-generator": "^14.0.0",
 				"@types/node": "^22.0.0",
-				"esbuild": "^0.27.0",
+				"esbuild": "^0.28.1",
 				"esbuild-plugin-copy": "^2.1.1",
 				"eslint": "9.39.4",
 				"eslint-plugin-obsidianmd": "0.3.0",
@@ -364,9 +364,9 @@
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-			"integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+			"integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -381,9 +381,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-			"integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+			"integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
 			"cpu": [
 				"arm"
 			],
@@ -398,9 +398,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-			"integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+			"integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
 			"cpu": [
 				"arm64"
 			],
@@ -415,9 +415,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-			"integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+			"integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
 			"cpu": [
 				"x64"
 			],
@@ -432,9 +432,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-			"integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+			"integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -449,9 +449,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-			"integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+			"integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
 			"cpu": [
 				"x64"
 			],
@@ -466,9 +466,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-			"integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
 			"cpu": [
 				"arm64"
 			],
@@ -483,9 +483,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-			"integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
 			"cpu": [
 				"x64"
 			],
@@ -500,9 +500,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-			"integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+			"integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
 			"cpu": [
 				"arm"
 			],
@@ -517,9 +517,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-			"integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+			"integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
 			"cpu": [
 				"arm64"
 			],
@@ -534,9 +534,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-			"integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+			"integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
 			"cpu": [
 				"ia32"
 			],
@@ -551,9 +551,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-			"integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+			"integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
 			"cpu": [
 				"loong64"
 			],
@@ -568,9 +568,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-			"integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+			"integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
 			"cpu": [
 				"mips64el"
 			],
@@ -585,9 +585,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-			"integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+			"integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -602,9 +602,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-			"integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+			"integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
 			"cpu": [
 				"riscv64"
 			],
@@ -619,9 +619,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-			"integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+			"integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
 			"cpu": [
 				"s390x"
 			],
@@ -636,9 +636,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-			"integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+			"integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
 			"cpu": [
 				"x64"
 			],
@@ -653,9 +653,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-			"integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
 			"cpu": [
 				"arm64"
 			],
@@ -670,9 +670,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-			"integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
 			"cpu": [
 				"x64"
 			],
@@ -687,9 +687,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-			"integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -704,9 +704,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-			"integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
 			"cpu": [
 				"x64"
 			],
@@ -721,9 +721,9 @@
 			}
 		},
 		"node_modules/@esbuild/openharmony-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-			"integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+			"integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
 			"cpu": [
 				"arm64"
 			],
@@ -738,9 +738,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-			"integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+			"integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
 			"cpu": [
 				"x64"
 			],
@@ -755,9 +755,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-			"integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+			"integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
 			"cpu": [
 				"arm64"
 			],
@@ -772,9 +772,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-			"integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+			"integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
 			"cpu": [
 				"ia32"
 			],
@@ -789,9 +789,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-			"integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+			"integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
 			"cpu": [
 				"x64"
 			],
@@ -2746,9 +2746,9 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4162,9 +4162,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-			"integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+			"integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -4175,32 +4175,32 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.27.3",
-				"@esbuild/android-arm": "0.27.3",
-				"@esbuild/android-arm64": "0.27.3",
-				"@esbuild/android-x64": "0.27.3",
-				"@esbuild/darwin-arm64": "0.27.3",
-				"@esbuild/darwin-x64": "0.27.3",
-				"@esbuild/freebsd-arm64": "0.27.3",
-				"@esbuild/freebsd-x64": "0.27.3",
-				"@esbuild/linux-arm": "0.27.3",
-				"@esbuild/linux-arm64": "0.27.3",
-				"@esbuild/linux-ia32": "0.27.3",
-				"@esbuild/linux-loong64": "0.27.3",
-				"@esbuild/linux-mips64el": "0.27.3",
-				"@esbuild/linux-ppc64": "0.27.3",
-				"@esbuild/linux-riscv64": "0.27.3",
-				"@esbuild/linux-s390x": "0.27.3",
-				"@esbuild/linux-x64": "0.27.3",
-				"@esbuild/netbsd-arm64": "0.27.3",
-				"@esbuild/netbsd-x64": "0.27.3",
-				"@esbuild/openbsd-arm64": "0.27.3",
-				"@esbuild/openbsd-x64": "0.27.3",
-				"@esbuild/openharmony-arm64": "0.27.3",
-				"@esbuild/sunos-x64": "0.27.3",
-				"@esbuild/win32-arm64": "0.27.3",
-				"@esbuild/win32-ia32": "0.27.3",
-				"@esbuild/win32-x64": "0.27.3"
+				"@esbuild/aix-ppc64": "0.28.1",
+				"@esbuild/android-arm": "0.28.1",
+				"@esbuild/android-arm64": "0.28.1",
+				"@esbuild/android-x64": "0.28.1",
+				"@esbuild/darwin-arm64": "0.28.1",
+				"@esbuild/darwin-x64": "0.28.1",
+				"@esbuild/freebsd-arm64": "0.28.1",
+				"@esbuild/freebsd-x64": "0.28.1",
+				"@esbuild/linux-arm": "0.28.1",
+				"@esbuild/linux-arm64": "0.28.1",
+				"@esbuild/linux-ia32": "0.28.1",
+				"@esbuild/linux-loong64": "0.28.1",
+				"@esbuild/linux-mips64el": "0.28.1",
+				"@esbuild/linux-ppc64": "0.28.1",
+				"@esbuild/linux-riscv64": "0.28.1",
+				"@esbuild/linux-s390x": "0.28.1",
+				"@esbuild/linux-x64": "0.28.1",
+				"@esbuild/netbsd-arm64": "0.28.1",
+				"@esbuild/netbsd-x64": "0.28.1",
+				"@esbuild/openbsd-arm64": "0.28.1",
+				"@esbuild/openbsd-x64": "0.28.1",
+				"@esbuild/openharmony-arm64": "0.28.1",
+				"@esbuild/sunos-x64": "0.28.1",
+				"@esbuild/win32-arm64": "0.28.1",
+				"@esbuild/win32-ia32": "0.28.1",
+				"@esbuild/win32-x64": "0.28.1"
 			}
 		},
 		"node_modules/esbuild-plugin-copy": {
@@ -6492,10 +6492,20 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -7245,9 +7255,9 @@
 			}
 		},
 		"node_modules/npm": {
-			"version": "11.14.1",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-11.14.1.tgz",
-			"integrity": "sha512-aopNZ0eEl6LbxoFcrXLmTEPzNBNxfiQnVgR9RmJBqzm+5h5pFoOmRljpRJbsXxocBeSl7GLcx3MoDf2UlEOjZw==",
+			"version": "11.17.0",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-11.17.0.tgz",
+			"integrity": "sha512-PurxiZexEHDTE4SSaLI3ZrnbAGiZfeyUcQcxcP5D+hfytNAze/D1IzDuInTn9XVLIbAQUnQuSPXJx02LHjLvQw==",
 			"bundleDependencies": [
 				"@isaacs/string-locale-compare",
 				"@npmcli/arborist",
@@ -7326,8 +7336,8 @@
 			],
 			"dependencies": {
 				"@isaacs/string-locale-compare": "^1.1.0",
-				"@npmcli/arborist": "^9.5.0",
-				"@npmcli/config": "^10.9.0",
+				"@npmcli/arborist": "^9.8.0",
+				"@npmcli/config": "^10.11.0",
 				"@npmcli/fs": "^5.0.0",
 				"@npmcli/map-workspaces": "^5.0.3",
 				"@npmcli/metavuln-calculator": "^9.0.3",
@@ -7345,27 +7355,27 @@
 				"fs-minipass": "^3.0.3",
 				"glob": "^13.0.6",
 				"graceful-fs": "^4.2.11",
-				"hosted-git-info": "^9.0.2",
+				"hosted-git-info": "^9.0.3",
 				"ini": "^6.0.0",
 				"init-package-json": "^8.2.5",
 				"is-cidr": "^6.0.4",
 				"json-parse-even-better-errors": "^5.0.0",
 				"libnpmaccess": "^10.0.3",
-				"libnpmdiff": "^8.1.7",
-				"libnpmexec": "^10.2.7",
-				"libnpmfund": "^7.0.21",
+				"libnpmdiff": "^8.1.10",
+				"libnpmexec": "^10.3.0",
+				"libnpmfund": "^7.0.24",
 				"libnpmorg": "^8.0.1",
-				"libnpmpack": "^9.1.7",
-				"libnpmpublish": "^11.1.3",
+				"libnpmpack": "^9.1.10",
+				"libnpmpublish": "^11.2.0",
 				"libnpmsearch": "^9.0.1",
 				"libnpmteam": "^8.0.2",
-				"libnpmversion": "^8.0.3",
-				"make-fetch-happen": "^15.0.5",
+				"libnpmversion": "^8.0.4",
+				"make-fetch-happen": "^15.0.6",
 				"minimatch": "^10.2.5",
 				"minipass": "^7.1.3",
 				"minipass-pipeline": "^1.2.4",
 				"ms": "^2.1.2",
-				"node-gyp": "^12.3.0",
+				"node-gyp": "^12.4.0",
 				"nopt": "^9.0.0",
 				"npm-audit-report": "^7.0.0",
 				"npm-install-checks": "^8.0.0",
@@ -7375,16 +7385,16 @@
 				"npm-registry-fetch": "^19.1.1",
 				"npm-user-validate": "^4.0.0",
 				"p-map": "^7.0.4",
-				"pacote": "^21.5.0",
+				"pacote": "^21.5.1",
 				"parse-conflict-json": "^5.0.1",
 				"proc-log": "^6.1.0",
 				"qrcode-terminal": "^0.12.0",
 				"read": "^5.0.1",
-				"semver": "^7.7.4",
+				"semver": "^7.8.4",
 				"spdx-expression-parse": "^4.0.0",
 				"ssri": "^13.0.1",
 				"supports-color": "^10.2.2",
-				"tar": "^7.5.13",
+				"tar": "^7.5.16",
 				"text-table": "~0.2.0",
 				"tiny-relative-date": "^2.0.2",
 				"treeverse": "^3.0.0",
@@ -7439,7 +7449,7 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/@npmcli/agent": {
-			"version": "4.0.0",
+			"version": "4.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -7455,7 +7465,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/arborist": {
-			"version": "9.5.0",
+			"version": "9.8.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -7503,7 +7513,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@npmcli/config": {
-			"version": "10.9.0",
+			"version": "10.11.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -7697,7 +7707,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/@sigstore/core": {
-			"version": "3.2.0",
+			"version": "3.2.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0",
@@ -7745,13 +7755,13 @@
 			}
 		},
 		"node_modules/npm/node_modules/@sigstore/verify": {
-			"version": "3.1.0",
+			"version": "3.1.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@sigstore/bundle": "^4.0.0",
-				"@sigstore/core": "^3.1.0",
+				"@sigstore/core": "^3.2.1",
 				"@sigstore/protobuf-specs": "^0.5.0"
 			},
 			"engines": {
@@ -7820,7 +7830,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/bin-links": {
-			"version": "6.0.0",
+			"version": "6.0.2",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -7848,7 +7858,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/brace-expansion": {
-			"version": "5.0.5",
+			"version": "5.0.6",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -8041,7 +8051,7 @@
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/hosted-git-info": {
-			"version": "9.0.2",
+			"version": "9.0.3",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -8140,7 +8150,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/ip-address": {
-			"version": "10.1.1",
+			"version": "10.2.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -8222,12 +8232,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmdiff": {
-			"version": "8.1.7",
+			"version": "8.1.10",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^9.5.0",
+				"@npmcli/arborist": "^9.8.0",
 				"@npmcli/installed-package-contents": "^4.0.0",
 				"binary-extensions": "^3.0.0",
 				"diff": "^8.0.2",
@@ -8241,13 +8251,13 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmexec": {
-			"version": "10.2.7",
+			"version": "10.3.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
 				"@gar/promise-retry": "^1.0.0",
-				"@npmcli/arborist": "^9.5.0",
+				"@npmcli/arborist": "^9.8.0",
 				"@npmcli/package-json": "^7.0.0",
 				"@npmcli/run-script": "^10.0.0",
 				"ci-info": "^4.0.0",
@@ -8264,12 +8274,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmfund": {
-			"version": "7.0.21",
+			"version": "7.0.24",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^9.5.0"
+				"@npmcli/arborist": "^9.8.0"
 			},
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
@@ -8289,12 +8299,12 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmpack": {
-			"version": "9.1.7",
+			"version": "9.1.10",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
-				"@npmcli/arborist": "^9.5.0",
+				"@npmcli/arborist": "^9.8.0",
 				"@npmcli/run-script": "^10.0.0",
 				"npm-package-arg": "^13.0.0",
 				"pacote": "^21.0.2"
@@ -8304,7 +8314,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmpublish": {
-			"version": "11.1.3",
+			"version": "11.2.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -8348,7 +8358,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/libnpmversion": {
-			"version": "8.0.3",
+			"version": "8.0.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -8364,7 +8374,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/lru-cache": {
-			"version": "11.3.5",
+			"version": "11.5.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "BlueOak-1.0.0",
@@ -8373,7 +8383,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/make-fetch-happen": {
-			"version": "15.0.5",
+			"version": "15.0.6",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -8539,7 +8549,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/node-gyp": {
-			"version": "12.3.0",
+			"version": "12.4.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -8716,7 +8726,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/pacote": {
-			"version": "21.5.0",
+			"version": "21.5.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -8777,7 +8787,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/postcss-selector-parser": {
-			"version": "7.1.1",
+			"version": "7.1.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -8874,7 +8884,7 @@
 			"optional": true
 		},
 		"node_modules/npm/node_modules/semver": {
-			"version": "7.7.4",
+			"version": "7.8.4",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -8898,17 +8908,17 @@
 			}
 		},
 		"node_modules/npm/node_modules/sigstore": {
-			"version": "4.1.0",
+			"version": "4.1.1",
 			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@sigstore/bundle": "^4.0.0",
-				"@sigstore/core": "^3.1.0",
+				"@sigstore/core": "^3.2.1",
 				"@sigstore/protobuf-specs": "^0.5.0",
-				"@sigstore/sign": "^4.1.0",
-				"@sigstore/tuf": "^4.0.1",
-				"@sigstore/verify": "^3.1.0"
+				"@sigstore/sign": "^4.1.1",
+				"@sigstore/tuf": "^4.0.2",
+				"@sigstore/verify": "^3.1.1"
 			},
 			"engines": {
 				"node": "^20.17.0 || >=22.9.0"
@@ -8925,7 +8935,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/socks": {
-			"version": "2.8.8",
+			"version": "2.8.9",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -8999,7 +9009,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/tar": {
-			"version": "7.5.13",
+			"version": "7.5.16",
 			"dev": true,
 			"inBundle": true,
 			"license": "BlueOak-1.0.0",
@@ -9027,7 +9037,7 @@
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/tinyglobby": {
-			"version": "0.2.16",
+			"version": "0.2.17",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -9095,7 +9105,7 @@
 			}
 		},
 		"node_modules/npm/node_modules/undici": {
-			"version": "6.25.0",
+			"version": "6.26.0",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
@@ -12044,9 +12054,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-			"integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+			"integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -12773,184 +12783,184 @@
 			"requires": {}
 		},
 		"@esbuild/aix-ppc64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
-			"integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+			"integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/android-arm": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
-			"integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+			"integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/android-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
-			"integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+			"integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/android-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
-			"integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+			"integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/darwin-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
-			"integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+			"integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/darwin-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
-			"integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+			"integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/freebsd-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
-			"integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/freebsd-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
-			"integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-arm": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
-			"integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+			"integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
-			"integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+			"integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-ia32": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
-			"integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+			"integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-loong64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
-			"integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+			"integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-mips64el": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
-			"integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+			"integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-ppc64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
-			"integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+			"integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-riscv64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
-			"integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+			"integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-s390x": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
-			"integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+			"integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/linux-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
-			"integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+			"integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/netbsd-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
-			"integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/netbsd-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
-			"integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/openbsd-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
-			"integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+			"integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/openbsd-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
-			"integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+			"integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/openharmony-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
-			"integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+			"integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/sunos-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
-			"integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+			"integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/win32-arm64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
-			"integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+			"integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/win32-ia32": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
-			"integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+			"integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
 			"dev": true,
 			"optional": true
 		},
 		"@esbuild/win32-x64": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
-			"integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+			"integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
 			"dev": true,
 			"optional": true
 		},
@@ -14221,9 +14231,9 @@
 			"dev": true
 		},
 		"brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
 			"dev": true,
 			"requires": {
 				"balanced-match": "^4.0.2"
@@ -15189,37 +15199,37 @@
 			}
 		},
 		"esbuild": {
-			"version": "0.27.3",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
-			"integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+			"version": "0.28.1",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+			"integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
 			"dev": true,
 			"requires": {
-				"@esbuild/aix-ppc64": "0.27.3",
-				"@esbuild/android-arm": "0.27.3",
-				"@esbuild/android-arm64": "0.27.3",
-				"@esbuild/android-x64": "0.27.3",
-				"@esbuild/darwin-arm64": "0.27.3",
-				"@esbuild/darwin-x64": "0.27.3",
-				"@esbuild/freebsd-arm64": "0.27.3",
-				"@esbuild/freebsd-x64": "0.27.3",
-				"@esbuild/linux-arm": "0.27.3",
-				"@esbuild/linux-arm64": "0.27.3",
-				"@esbuild/linux-ia32": "0.27.3",
-				"@esbuild/linux-loong64": "0.27.3",
-				"@esbuild/linux-mips64el": "0.27.3",
-				"@esbuild/linux-ppc64": "0.27.3",
-				"@esbuild/linux-riscv64": "0.27.3",
-				"@esbuild/linux-s390x": "0.27.3",
-				"@esbuild/linux-x64": "0.27.3",
-				"@esbuild/netbsd-arm64": "0.27.3",
-				"@esbuild/netbsd-x64": "0.27.3",
-				"@esbuild/openbsd-arm64": "0.27.3",
-				"@esbuild/openbsd-x64": "0.27.3",
-				"@esbuild/openharmony-arm64": "0.27.3",
-				"@esbuild/sunos-x64": "0.27.3",
-				"@esbuild/win32-arm64": "0.27.3",
-				"@esbuild/win32-ia32": "0.27.3",
-				"@esbuild/win32-x64": "0.27.3"
+				"@esbuild/aix-ppc64": "0.28.1",
+				"@esbuild/android-arm": "0.28.1",
+				"@esbuild/android-arm64": "0.28.1",
+				"@esbuild/android-x64": "0.28.1",
+				"@esbuild/darwin-arm64": "0.28.1",
+				"@esbuild/darwin-x64": "0.28.1",
+				"@esbuild/freebsd-arm64": "0.28.1",
+				"@esbuild/freebsd-x64": "0.28.1",
+				"@esbuild/linux-arm": "0.28.1",
+				"@esbuild/linux-arm64": "0.28.1",
+				"@esbuild/linux-ia32": "0.28.1",
+				"@esbuild/linux-loong64": "0.28.1",
+				"@esbuild/linux-mips64el": "0.28.1",
+				"@esbuild/linux-ppc64": "0.28.1",
+				"@esbuild/linux-riscv64": "0.28.1",
+				"@esbuild/linux-s390x": "0.28.1",
+				"@esbuild/linux-x64": "0.28.1",
+				"@esbuild/netbsd-arm64": "0.28.1",
+				"@esbuild/netbsd-x64": "0.28.1",
+				"@esbuild/openbsd-arm64": "0.28.1",
+				"@esbuild/openbsd-x64": "0.28.1",
+				"@esbuild/openharmony-arm64": "0.28.1",
+				"@esbuild/sunos-x64": "0.28.1",
+				"@esbuild/win32-arm64": "0.28.1",
+				"@esbuild/win32-ia32": "0.28.1",
+				"@esbuild/win32-x64": "0.28.1"
 			}
 		},
 		"esbuild-plugin-copy": {
@@ -16734,9 +16744,9 @@
 			"dev": true
 		},
 		"js-yaml": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+			"integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
 			"dev": true,
 			"requires": {
 				"argparse": "^2.0.1"
@@ -17272,14 +17282,14 @@
 			"dev": true
 		},
 		"npm": {
-			"version": "11.14.1",
-			"resolved": "https://registry.npmjs.org/npm/-/npm-11.14.1.tgz",
-			"integrity": "sha512-aopNZ0eEl6LbxoFcrXLmTEPzNBNxfiQnVgR9RmJBqzm+5h5pFoOmRljpRJbsXxocBeSl7GLcx3MoDf2UlEOjZw==",
+			"version": "11.17.0",
+			"resolved": "https://registry.npmjs.org/npm/-/npm-11.17.0.tgz",
+			"integrity": "sha512-PurxiZexEHDTE4SSaLI3ZrnbAGiZfeyUcQcxcP5D+hfytNAze/D1IzDuInTn9XVLIbAQUnQuSPXJx02LHjLvQw==",
 			"dev": true,
 			"requires": {
 				"@isaacs/string-locale-compare": "^1.1.0",
-				"@npmcli/arborist": "^9.5.0",
-				"@npmcli/config": "^10.9.0",
+				"@npmcli/arborist": "^9.8.0",
+				"@npmcli/config": "^10.11.0",
 				"@npmcli/fs": "^5.0.0",
 				"@npmcli/map-workspaces": "^5.0.3",
 				"@npmcli/metavuln-calculator": "^9.0.3",
@@ -17297,27 +17307,27 @@
 				"fs-minipass": "^3.0.3",
 				"glob": "^13.0.6",
 				"graceful-fs": "^4.2.11",
-				"hosted-git-info": "^9.0.2",
+				"hosted-git-info": "^9.0.3",
 				"ini": "^6.0.0",
 				"init-package-json": "^8.2.5",
 				"is-cidr": "^6.0.4",
 				"json-parse-even-better-errors": "^5.0.0",
 				"libnpmaccess": "^10.0.3",
-				"libnpmdiff": "^8.1.7",
-				"libnpmexec": "^10.2.7",
-				"libnpmfund": "^7.0.21",
+				"libnpmdiff": "^8.1.10",
+				"libnpmexec": "^10.3.0",
+				"libnpmfund": "^7.0.24",
 				"libnpmorg": "^8.0.1",
-				"libnpmpack": "^9.1.7",
-				"libnpmpublish": "^11.1.3",
+				"libnpmpack": "^9.1.10",
+				"libnpmpublish": "^11.2.0",
 				"libnpmsearch": "^9.0.1",
 				"libnpmteam": "^8.0.2",
-				"libnpmversion": "^8.0.3",
-				"make-fetch-happen": "^15.0.5",
+				"libnpmversion": "^8.0.4",
+				"make-fetch-happen": "^15.0.6",
 				"minimatch": "^10.2.5",
 				"minipass": "^7.1.3",
 				"minipass-pipeline": "^1.2.4",
 				"ms": "^2.1.2",
-				"node-gyp": "^12.3.0",
+				"node-gyp": "^12.4.0",
 				"nopt": "^9.0.0",
 				"npm-audit-report": "^7.0.0",
 				"npm-install-checks": "^8.0.0",
@@ -17327,16 +17337,16 @@
 				"npm-registry-fetch": "^19.1.1",
 				"npm-user-validate": "^4.0.0",
 				"p-map": "^7.0.4",
-				"pacote": "^21.5.0",
+				"pacote": "^21.5.1",
 				"parse-conflict-json": "^5.0.1",
 				"proc-log": "^6.1.0",
 				"qrcode-terminal": "^0.12.0",
 				"read": "^5.0.1",
-				"semver": "^7.7.4",
+				"semver": "^7.8.4",
 				"spdx-expression-parse": "^4.0.0",
 				"ssri": "^13.0.1",
 				"supports-color": "^10.2.2",
-				"tar": "^7.5.13",
+				"tar": "^7.5.16",
 				"text-table": "~0.2.0",
 				"tiny-relative-date": "^2.0.2",
 				"treeverse": "^3.0.0",
@@ -17363,7 +17373,7 @@
 					"dev": true
 				},
 				"@npmcli/agent": {
-					"version": "4.0.0",
+					"version": "4.0.2",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -17375,7 +17385,7 @@
 					}
 				},
 				"@npmcli/arborist": {
-					"version": "9.5.0",
+					"version": "9.8.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -17416,7 +17426,7 @@
 					}
 				},
 				"@npmcli/config": {
-					"version": "10.9.0",
+					"version": "10.11.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -17551,7 +17561,7 @@
 					}
 				},
 				"@sigstore/core": {
-					"version": "3.2.0",
+					"version": "3.2.1",
 					"bundled": true,
 					"dev": true
 				},
@@ -17583,12 +17593,12 @@
 					}
 				},
 				"@sigstore/verify": {
-					"version": "3.1.0",
+					"version": "3.1.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"@sigstore/bundle": "^4.0.0",
-						"@sigstore/core": "^3.1.0",
+						"@sigstore/core": "^3.2.1",
 						"@sigstore/protobuf-specs": "^0.5.0"
 					}
 				},
@@ -17632,7 +17642,7 @@
 					"dev": true
 				},
 				"bin-links": {
-					"version": "6.0.0",
+					"version": "6.0.2",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -17649,7 +17659,7 @@
 					"dev": true
 				},
 				"brace-expansion": {
-					"version": "5.0.5",
+					"version": "5.0.6",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -17760,7 +17770,7 @@
 					"dev": true
 				},
 				"hosted-git-info": {
-					"version": "9.0.2",
+					"version": "9.0.3",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -17826,7 +17836,7 @@
 					}
 				},
 				"ip-address": {
-					"version": "10.1.1",
+					"version": "10.2.0",
 					"bundled": true,
 					"dev": true
 				},
@@ -17878,11 +17888,11 @@
 					}
 				},
 				"libnpmdiff": {
-					"version": "8.1.7",
+					"version": "8.1.10",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"@npmcli/arborist": "^9.5.0",
+						"@npmcli/arborist": "^9.8.0",
 						"@npmcli/installed-package-contents": "^4.0.0",
 						"binary-extensions": "^3.0.0",
 						"diff": "^8.0.2",
@@ -17893,12 +17903,12 @@
 					}
 				},
 				"libnpmexec": {
-					"version": "10.2.7",
+					"version": "10.3.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"@gar/promise-retry": "^1.0.0",
-						"@npmcli/arborist": "^9.5.0",
+						"@npmcli/arborist": "^9.8.0",
 						"@npmcli/package-json": "^7.0.0",
 						"@npmcli/run-script": "^10.0.0",
 						"ci-info": "^4.0.0",
@@ -17912,11 +17922,11 @@
 					}
 				},
 				"libnpmfund": {
-					"version": "7.0.21",
+					"version": "7.0.24",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"@npmcli/arborist": "^9.5.0"
+						"@npmcli/arborist": "^9.8.0"
 					}
 				},
 				"libnpmorg": {
@@ -17929,18 +17939,18 @@
 					}
 				},
 				"libnpmpack": {
-					"version": "9.1.7",
+					"version": "9.1.10",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"@npmcli/arborist": "^9.5.0",
+						"@npmcli/arborist": "^9.8.0",
 						"@npmcli/run-script": "^10.0.0",
 						"npm-package-arg": "^13.0.0",
 						"pacote": "^21.0.2"
 					}
 				},
 				"libnpmpublish": {
-					"version": "11.1.3",
+					"version": "11.2.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -17972,7 +17982,7 @@
 					}
 				},
 				"libnpmversion": {
-					"version": "8.0.3",
+					"version": "8.0.4",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -17984,12 +17994,12 @@
 					}
 				},
 				"lru-cache": {
-					"version": "11.3.5",
+					"version": "11.5.1",
 					"bundled": true,
 					"dev": true
 				},
 				"make-fetch-happen": {
-					"version": "15.0.5",
+					"version": "15.0.6",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -18102,7 +18112,7 @@
 					"dev": true
 				},
 				"node-gyp": {
-					"version": "12.3.0",
+					"version": "12.4.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -18218,7 +18228,7 @@
 					"dev": true
 				},
 				"pacote": {
-					"version": "21.5.0",
+					"version": "21.5.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -18261,7 +18271,7 @@
 					}
 				},
 				"postcss-selector-parser": {
-					"version": "7.1.1",
+					"version": "7.1.4",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -18322,7 +18332,7 @@
 					"optional": true
 				},
 				"semver": {
-					"version": "7.7.4",
+					"version": "7.8.4",
 					"bundled": true,
 					"dev": true
 				},
@@ -18332,16 +18342,16 @@
 					"dev": true
 				},
 				"sigstore": {
-					"version": "4.1.0",
+					"version": "4.1.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"@sigstore/bundle": "^4.0.0",
-						"@sigstore/core": "^3.1.0",
+						"@sigstore/core": "^3.2.1",
 						"@sigstore/protobuf-specs": "^0.5.0",
-						"@sigstore/sign": "^4.1.0",
-						"@sigstore/tuf": "^4.0.1",
-						"@sigstore/verify": "^3.1.0"
+						"@sigstore/sign": "^4.1.1",
+						"@sigstore/tuf": "^4.0.2",
+						"@sigstore/verify": "^3.1.1"
 					}
 				},
 				"smart-buffer": {
@@ -18350,7 +18360,7 @@
 					"dev": true
 				},
 				"socks": {
-					"version": "2.8.8",
+					"version": "2.8.9",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -18401,7 +18411,7 @@
 					"dev": true
 				},
 				"tar": {
-					"version": "7.5.13",
+					"version": "7.5.16",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -18423,7 +18433,7 @@
 					"dev": true
 				},
 				"tinyglobby": {
-					"version": "0.2.16",
+					"version": "0.2.17",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -18460,7 +18470,7 @@
 					}
 				},
 				"undici": {
-					"version": "6.25.0",
+					"version": "6.26.0",
 					"bundled": true,
 					"dev": true
 				},
@@ -20396,9 +20406,9 @@
 			}
 		},
 		"undici": {
-			"version": "7.25.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-			"integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+			"integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
 			"dev": true
 		},
 		"undici-types": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
 	"author": "Marcus Breiden",
 	"repository": "https://github.com/MMoMM-org/obsidian-dynbedded.git",
-	"dependencies": {},
 	"description": "Embed files or header sections with optional date-based filename substitution.",
 	"devDependencies": {
 		"@eslint/js": "9.39.4",
@@ -10,7 +9,7 @@
 		"@semantic-release/git": "^10.0.1",
 		"@semantic-release/release-notes-generator": "^14.0.0",
 		"@types/node": "^22.0.0",
-		"esbuild": "^0.27.0",
+		"esbuild": "^0.28.1",
 		"esbuild-plugin-copy": "^2.1.1",
 		"eslint": "9.39.4",
 		"eslint-plugin-obsidianmd": "0.3.0",


### PR DESCRIPTION
Resolves 4 of 5 open Dependabot alerts. All affected packages are
`devDependencies` — none ship in the plugin bundle (`dependencies` is
empty, esbuild bundles everything with `obsidian` external).

## Fixed

| # | Package | Severity | How |
|---|---------|----------|-----|
| #44 | undici | high | `npm audit fix` (via semantic-release) |
| #43 | undici | medium | `npm audit fix` |
| #41 | js-yaml | medium | `npm audit fix` (via eslint/semantic-release) |
| #38 | esbuild | low | manual bump `^0.27.0` → `^0.28.0` (fix is 0.28.1, outside caret range) |

Also clears brace-expansion (moderate). `npm audit` now reports **0 vulnerabilities**.

## Verified

- `npm run build` passes; bundle output unchanged (`build/main.js` 32.9kb)
- CLAUDE.md esbuild reference updated 0.27 → 0.28

## Not fixed

**#42 (tar, medium)** — npm's own vendored `tar` under `node_modules/npm`,
only updatable via an npm release, not controllable from this repo. Affects
CI tooling only, never the plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)