### PR TITLE
fix(release): conventionalcommits preset so semantic-release keeps ! commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,23 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release
 
+      # Catch the silent-drop class where a release-worthy feat/fix commit
+      # produces no release (e.g. commit-analyzer left on the angular preset,
+      # whose headerPattern has no '!' and drops feat!:/fix!: commits). If a
+      # release was cut, the new tag is the most recent reachable one and the
+      # range below is empty of feat/fix; if not, the dropped commit is still
+      # in range → fail.
+      - name: Guard against silently-dropped releases
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          RANGE="${LAST_TAG:+$LAST_TAG..}HEAD"
+          if git log "$RANGE" --format='%s' | grep -qE '^(feat|fix)(\(.+\))?!?:'; then
+              echo "::error::Release-worthy feat/fix commit(s) present since ${LAST_TAG:-<root>} but no release was cut — likely a commit-analyzer preset/config drop (angular preset ignores '!')."
+              git log "$RANGE" --format='  %s' | grep -E '^  (feat|fix)(\(.+\))?!?:'
+              exit 1
+          fi
+          echo "Release guard OK (no un-released feat/fix commits since ${LAST_TAG:-<root>})."
+
       - name: Attest release assets
         # Only runs when semantic-release actually built artifacts
         # (no-op commits like docs/chore won't populate build/).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-dynbedded",
-	"version": "1.5.0",
+	"version": "1.6.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-dynbedded",
-			"version": "1.5.0",
+			"version": "1.6.0",
 			"license": "GPLv3",
 			"devDependencies": {
 				"@eslint/js": "9.39.4",
@@ -15,6 +15,7 @@
 				"@semantic-release/git": "^10.0.1",
 				"@semantic-release/release-notes-generator": "^14.0.0",
 				"@types/node": "^22.0.0",
+				"conventional-changelog-conventionalcommits": "^9.0.0",
 				"esbuild": "^0.28.1",
 				"esbuild-plugin-copy": "^2.1.1",
 				"eslint": "9.39.4",
@@ -3181,6 +3182,19 @@
 			"version": "8.3.0",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.0.tgz",
 			"integrity": "sha512-DOuBwYSqWzfwuRByY9O4oOIvDlkUCTDzfbOgcSbkY+imXXj+4tmrEFao3K+FxemClYfYnZzsvudbwrhje9VHDA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"compare-func": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/conventional-changelog-conventionalcommits": {
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+			"integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -14526,6 +14540,15 @@
 			"version": "8.3.0",
 			"resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.0.tgz",
 			"integrity": "sha512-DOuBwYSqWzfwuRByY9O4oOIvDlkUCTDzfbOgcSbkY+imXXj+4tmrEFao3K+FxemClYfYnZzsvudbwrhje9VHDA==",
+			"dev": true,
+			"requires": {
+				"compare-func": "^2.0.0"
+			}
+		},
+		"conventional-changelog-conventionalcommits": {
+			"version": "9.3.1",
+			"resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+			"integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
 			"dev": true,
 			"requires": {
 				"compare-func": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 		"@semantic-release/git": "^10.0.1",
 		"@semantic-release/release-notes-generator": "^14.0.0",
 		"@types/node": "^22.0.0",
+		"conventional-changelog-conventionalcommits": "^9.0.0",
 		"esbuild": "^0.28.1",
 		"esbuild-plugin-copy": "^2.1.1",
 		"eslint": "9.39.4",
@@ -44,14 +45,23 @@
 	"version": "1.6.0",
 	"release": {
 		"private": false,
-		"preset": "angular",
 		"branches": [
 			"main"
 		],
 		"tagFormat": "${version}",
 		"plugins": [
-			"@semantic-release/commit-analyzer",
-			"@semantic-release/release-notes-generator",
+			[
+				"@semantic-release/commit-analyzer",
+				{
+					"preset": "conventionalcommits"
+				}
+			],
+			[
+				"@semantic-release/release-notes-generator",
+				{
+					"preset": "conventionalcommits"
+				}
+			],
 			[
 				"@semantic-release/changelog",
 				{


### PR DESCRIPTION
## Problem

semantic-release's `commit-analyzer` and `release-notes-generator` were left on the **angular** default preset. The angular `headerPattern` has no `!` marker, so `feat!:` / `fix!:` breaking-change commits were **silently dropped** — they produced no release at all.

## Change

- Switch both plugins to the **conventionalcommits** preset (honours the `!` breaking marker) via per-plugin option blocks in `package.json`'s `release` section.
- Remove the ineffective top-level `"preset": "angular"` — config now lives in the plugin blocks.
- Add `conventional-changelog-conventionalcommits@^9` devDep (+ lockfile).
- Add a CI guard step in `release.yml` that **fails the release job** when a release-worthy `feat`/`fix` commit exists since the last tag but no release was cut — catching this whole silent-drop class going forward.

## Notes

Policy/preset logic was set by a prior session and is intentionally left unchanged; this PR completes it (lockfile + commit + guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)