### PR TITLE
chore(deps): override undici to ^6.27.0 in release toolchain

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,9 +64,9 @@
 			}
 		},
 		"node_modules/@actions/http-client/node_modules/undici": {
-			"version": "6.25.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-			"integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+			"version": "6.27.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+			"integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -12630,13 +12630,13 @@
 			"dev": true,
 			"requires": {
 				"tunnel": "^0.0.6",
-				"undici": "^6.23.0"
+				"undici": "^6.27.0"
 			},
 			"dependencies": {
 				"undici": {
-					"version": "6.25.0",
-					"resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
-					"integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
+					"version": "6.27.0",
+					"resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+					"integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
 					"dev": true
 				}
 			}
@@ -18147,7 +18147,7 @@
 						"semver": "^7.3.5",
 						"tar": "^7.5.4",
 						"tinyglobby": "^0.2.12",
-						"undici": "^6.25.0",
+						"undici": "^6.27.0",
 						"which": "^6.0.0"
 					}
 				},

--- a/package.json
+++ b/package.json
@@ -27,6 +27,14 @@
 	"browserslist": [
 		"chrome 114"
 	],
+	"overrides": {
+		"@actions/http-client": {
+			"undici": "^6.27.0"
+		},
+		"node-gyp": {
+			"undici": "^6.27.0"
+		}
+	},
 	"keywords": [],
 	"license": "GPLv3",
 	"main": "src/main.js",


### PR DESCRIPTION
## Context

Dependabot flagged `undici` advisories. All copies are pulled **only by `semantic-release`** (dev/CI-only) and are **never bundled into the shipped plugin** (`build/main.js` is esbuild-built from `src/` + the Obsidian API). No runtime exposure for plugin users.

## Change

Scoped `overrides` bumping the **live release-path** copy — `@actions/http-client → undici` (used by `@actions/core` during the GitHub Actions release) — from 6.25.0 to 6.27.0.

- Clean lockfile diff: only the undici version bump, **no** cross-platform `@esbuild/*` binaries (which `npm audit fix` would have added).
- Does not touch the already-safe `@semantic-release/github → undici@7.28.0`.

## Residual (dismissed as dev-only)

`npm → node-gyp → undici@6.26.0` is **bundled inside the `npm` CLI package**, so `overrides` can't rewrite it. It's dormant here (pure-JS plugin, `npmPublish:false`, no native builds) and unfixable until `@semantic-release/npm` bumps its bundled npm. The corresponding Dependabot alerts are dismissed with that rationale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)